### PR TITLE
Moved buttons and other things

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -37,7 +37,7 @@ a {
     overflow-y: auto;
     overflow-x: hidden;
     padding: 5px 0;
-    margin: 35px 0 0 !important;
+    margin: 67px 0 0 !important;
     font-size: 14px;
     text-align: left;
     list-style: none;
@@ -52,7 +52,8 @@ a {
 }
 
 .kaminoButton {
-    float: right;
+    float: right !important;
+    margin: 5px 0 5px 5px !important;
 }
 
 .open>.dropdown-menu {

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,7 @@
     "icons": {
         "128": "icons/storm-trooper-128.png"
     },
+    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
     "manifest_version": 2,
     "name": "Kamino",
     "options_page": "options.html",


### PR DESCRIPTION
The original issue was that when a partial refresh of the page was executed, the clone button would disappear. This is fixed as well as the other following things:

- Added a `setInterval` call that will re-initialize the button if it doesn't already exist in the DOM. This fixes the button disappearing after closing or re-opening the issue
- Added a more relaxed content script policy to allow for `setInterval`
- Fixed an issue with the Bootstrap modal not working because of the removal of the Bootstrap javascript file
- Clear the repo list before populating to avoid duplicates