### PR TITLE
Most Used

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,9 @@ function initializeExtension() {
     $('.gh-header-actions').append(btn)
     $('.gh-header-actions').append(popup)
 
+    // remove the open class just to be sure
+    $('.dropdown').removeClass('open');
+
     // load the token
     chrome.storage.sync.get({
       githubToken: ''


### PR DESCRIPTION
- When the user clones to a repo, it gets added to a most used list saved in `chrome.storage`
- If the item already exists, it removes the item, pushes to the top
- If there are more than 5 items in the list, it pops the last item
- The items in most used are not in the main repo list
- Items are separated with `Most Used` and `The Rest`
- Fixed a bug(#53) that wouldn't allow cloning to repos that had a `.`