### PR TITLE
user setting go to issues list

### DIFF
--- a/app.js
+++ b/app.js
@@ -160,11 +160,19 @@ function commentOnIssue(repo, oldIssue, newIssue) {
     (response) => {
       // if success, close the existing issue and open new in a new tab
       closeGithubIssue(oldIssue)
-      window.open('https://github.com/' + repo + '/issues/' + newIssue.number, "_blank")
+
+      goToIssueList(repo, newIssue.number, urlObj.organization, urlObj.currentRepo)
     },
     (error) => {
       console.error(error)
     })
+}
+
+function goToIssueList(repo, issueNumber, org, oldRepo) {
+  // based on user settings, determines if the issues list will open after a clone or not
+  chrome.runtime.sendMessage({ repo: repo, issueNumber: issueNumber, organization: org, oldRepo: oldRepo }, (response) => {
+    console.log(response.farewell)
+  })
 }
 
 function ajaxRequest(type, data, url, successCallback, errorCallback) {

--- a/background.js
+++ b/background.js
@@ -15,3 +15,23 @@ chrome.runtime.onInstalled.addListener((details) => {
         })
     }
 })
+
+// listen for tab change requests
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    // get settings
+    chrome.storage.sync.get({
+        goToList: false
+    }, (item) => {
+        if (item.goToList) {
+            // if user setting is set, open issue list and set focus and open cloned issue in tab
+            chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
+                chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: false })
+                chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + '/issues', selected: true })
+            })
+        }
+        else {
+            // if user setting is not set, open open cloned issue in new tab and set focus to that tab
+            chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: true })
+        }
+    })
+})

--- a/manifest.json
+++ b/manifest.json
@@ -28,6 +28,7 @@
     "options_page": "options.html",
     "permissions": [
         "tabs",
+        "background",
         "storage",
         "webNavigation",
         "*://github.com/*"

--- a/options.html
+++ b/options.html
@@ -29,16 +29,21 @@
 
 
     <div id="tabpages" class="ui-tabs ui-widget ui-widget-content ui-corner-all" style="display: block;">
-       
+
         <div id="ui-tabs-1" class="ui-tabs-panel ui-widget-content ui-corner-bottom" aria-live="polite" aria-labelledby="ui-id-1"
             role="tabpanel" aria-expanded="true" aria-hidden="false">
             <!-- required to help Safari not get confused when injecting this fragment -->
             <div>
                 <h2 id="generaloptions">General Settings</h2>
-                
+
                 <p>
                     <label>GitHub Personal Access Token:</label>
-                    <input type="text" id="github-pat"/>
+                    <input type="text" id="github-pat" />
+                </p>
+
+                <p>
+                    <label>Go to organization's issue list after cloning</label>
+                    <input type="checkbox" id="go-to-issue-list" />
                 </p>
             </div>
 

--- a/options.js
+++ b/options.js
@@ -1,8 +1,11 @@
 // Saves options to chrome.storage
 function save_options() {
   var token = document.getElementById('github-pat').value;
+  var goToList = document.getElementById('go-to-issue-list').checked;
+
   chrome.storage.sync.set({
-    githubToken: token
+    githubToken: token,
+    goToList: goToList
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -16,9 +19,11 @@ function save_options() {
 // Restores options
 function restore_options() {
   chrome.storage.sync.get({
-    githubToken: ''
+    githubToken: '',
+    goToList: false
   }, function(items) {
     document.getElementById('github-pat').value = items.githubToken;
+    document.getElementById('go-to-issue-list').checked = items.goToList;
   });
 }
 


### PR DESCRIPTION
- added option for `Go to organization's issue list after cloning`
- if the setting is checked, after cloning, Kamino will navigate to the issue list of the organization the user is cloning from and the tab will stay focused. It will also create the tab pointing to the new issue like it has done prior.
- if the setting is not checked, the extension will behave as it always has