### PR TITLE
add option to create tab of cloned issue

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,20 +20,25 @@ chrome.runtime.onInstalled.addListener((details) => {
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // get settings
     chrome.storage.sync.get({
-        goToList: false
+        goToList: false,
+        createTab: true
     }, (item) => {
         if (item.goToList) {
             // if user setting is set, open issue list and set focus and open cloned issue in tab
             chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
                 setTimeout(() => {
-                    chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: false })
+                    if(item.createTab) {
+                        chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: false })
+                    }
                     chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + '/issues', selected: true })
                 }, 1000)
             })
         }
         else {
-            // if user setting is not set, open open cloned issue in new tab and set focus to that tab
-            setTimeout(() => { chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: true }) }, 1000)
+            if(item.createTab) {
+                // if user setting is not set, open open cloned issue in new tab and set focus to that tab
+                setTimeout(() => { chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: true }) }, 1000)
+            }
         }
     })
 })

--- a/options.html
+++ b/options.html
@@ -45,6 +45,11 @@
                     <label>Go to organization's issue list after cloning</label>
                     <input type="checkbox" id="go-to-issue-list" />
                 </p>
+                
+                <p>
+                    <label>Create tab for cloned issue</label>
+                    <input type="checkbox" id="create-tab" />
+                </p>
             </div>
 
             <p>

--- a/options.js
+++ b/options.js
@@ -2,10 +2,12 @@
 function save_options() {
   var token = document.getElementById('github-pat').value;
   var goToList = document.getElementById('go-to-issue-list').checked;
+  var createTab = document.getElementById('create-tab').checked;
 
   chrome.storage.sync.set({
     githubToken: token,
-    goToList: goToList
+    goToList: goToList,
+    createTab: createTab
   }, function() {
     // Update status to let user know options were saved.
     var status = document.getElementById('status');
@@ -20,10 +22,12 @@ function save_options() {
 function restore_options() {
   chrome.storage.sync.get({
     githubToken: '',
-    goToList: false
+    goToList: false,
+    createTab: true
   }, function(items) {
     document.getElementById('github-pat').value = items.githubToken;
     document.getElementById('go-to-issue-list').checked = items.goToList;
+    document.getElementById('create-tab').checked = items.createTab;
   });
 }
 


### PR DESCRIPTION
Option called `Create tab for cloned issue`. By default is checked. If checked, when cloning the new cloned issue will open in a new tab. If not checked, the tab will not be created.