### PR TITLE
save issue filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ In your Google Chrome browser, simply look for Kamino in the Chrome Extensions s
 
 If you don't know how to create a PAT or need help, check out Creating a token section [here](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
 
-Once you have your PAT, enter it on the Options screen for Kamino and click `Save`. After that is done, go to any Github issue page in which you are a member and you should see a button labeled `Clone issue to`.
+Once you have your PAT, enter it on the Options screen for Kamino and click `Save`. After that is done, go to any Github issue page in which you are a member and you should see a button labeled `Clone to`.
 
 # Features
 
 ## Normal operations
-Clicking this button will display a dropdown list of repos. Selecting a repo will ask for confirmation about cloning the issue. If you then click `Yes`, the issue will be cloned to the new repository and the original issue will be closed.
+Clicking this button will display a dropdown list of repos. Selecting a repo will ask for confirmation about cloning the issue. If you then click `Yes`, the issue will be cloned to the new repository and the original issue will be closed. There are user settings for opening the new issue in a tab as well as navigating back to the original issue's repository issues list and these things will happen after Kamino has cloned the issue.
 
 ## Last used
 Kamino will remember the last 5 repositories you cloned to so that it will be easy for you to find. If you are someone that is a member of a lot of repos, this should be very handy!
@@ -21,7 +21,7 @@ Kamino will remember the last 5 repositories you cloned to so that it will be ea
 Kamino now supports a quick clone feature. The last repository you cloned to will be shown on a button next to the dropdown. Rather than having to pick the item from the repo list, you can simply click the button to clone to your last used repository!
 
 ### How does it work?
-Kamino leverages the Github API to gather information about the issue you are on. Kamino uses a Chrome Extension utilizing content scripts to create a button on specific web pages.
+Kamino leverages the Github API to gather information about the issue you are on. Kamino is a chrome extension utilizing content scripts to create a button on specific web pages, specifically Github issue pages.
 
 ### Wait a minute, something's not working! Or I'd like to leave feedback
 If you find an issue, feel free to create an issue here. If you think of a way Kamino can be enhanced, also create an issue outlining your feature.

--- a/app.js
+++ b/app.js
@@ -80,7 +80,7 @@ function initializeExtension() {
 
 function saveAppliedFilters(urlObj) {
   // this check should indicate there are applied filters other than the defaults
-  if (urlObj.url.indexOf('&q=')) {
+  if (urlObj.url.indexOf('q=')) {
     // save the filter querystring for when/if we navigate back
     var url = urlObj.url
     console.log(url)

--- a/app.js
+++ b/app.js
@@ -28,6 +28,9 @@ function initializeExtension() {
 
   // if the page is not a pull request page and there is no Kamino button in the DOM, proceed
   if (urlObj.url.indexOf('/pull/') < 0 && $('.kaminoButton').length === 0) {
+    // look for any applied issue filters
+    saveAppliedFilters(urlObj)
+
     // append button and modal to DOM
     $(newBtn).insertAfter($('.sidebar-milestone'))
     $(popup).insertAfter($('.sidebar-milestone'))
@@ -71,6 +74,26 @@ function initializeExtension() {
 
     $('.noClone').click(() => {
       closeModal()
+    })
+  }
+}
+
+function saveAppliedFilters(urlObj) {
+  // this check should indicate there are applied filters other than the defaults
+  if (urlObj.url.indexOf('&q=')) {
+    // save the filter querystring for when/if we navigate back
+    var url = urlObj.url
+    console.log(url)
+    var querystring = url.substring(url.indexOf('q='))
+
+    chrome.storage.sync.get({
+      filters: ''
+    }, (item) => {
+      if (item.filters !== querystring) {
+        chrome.storage.sync.set({
+          filters: querystring
+        }, () => { })
+      }
     })
   }
 }

--- a/app.js
+++ b/app.js
@@ -83,7 +83,6 @@ function saveAppliedFilters(urlObj) {
   if (urlObj.url.indexOf('q=')) {
     // save the filter querystring for when/if we navigate back
     var url = urlObj.url
-    console.log(url)
     var querystring = url.substring(url.indexOf('q='))
 
     chrome.storage.sync.get({

--- a/background.js
+++ b/background.js
@@ -21,7 +21,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     // get settings
     chrome.storage.sync.get({
         goToList: false,
-        createTab: true
+        createTab: true,
+        filters: ''
     }, (item) => {
         if (item.goToList) {
             // if user setting is set, open issue list and set focus and open cloned issue in tab
@@ -30,7 +31,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
                     if(item.createTab) {
                         chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: false })
                     }
-                    chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + '/issues', selected: true })
+                    chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + '/issues?' + filters, selected: true })
                 }, 1000)
             })
         }


### PR DESCRIPTION
- whenever landing on the issues list screen, look for any applied filters other than the defaults
- if there are filters and the filters are different than the already stored filters, save them
- whenever cloning, retrieve the filters and apply them to the url if the go to issue list user option is turned on.
- updated read.me a little bit