### PR TITLE
fixed issue with filtering

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,6 +100,11 @@ function saveAppliedFilters(urlObj) {
       var exists = false;
       var changed = false;
 
+      // convert the string to an empty array for existing users
+      if(typeof item.filters === 'string') {
+        item.filters = []
+      }
+
       item.filters.forEach((f) => {
         // if the storage array contains the org and repo, then set exists flag
         if (f.organization === filter.organization && f.currentRepo === filter.currentRepo) {

--- a/app.js
+++ b/app.js
@@ -79,18 +79,50 @@ function initializeExtension() {
 }
 
 function saveAppliedFilters(urlObj) {
-  // this check should indicate there are applied filters other than the defaults
-  if (urlObj.url.indexOf('q=') > 0) {
+  // check for the appropriate url
+  // url should have /issues and should not track any url that has an issue number at the end
+  if (urlObj.url.indexOf('/issues') > 0 && isNaN(urlObj.issueNumber)) {
     // save the filter querystring for when/if we navigate back
     var url = urlObj.url
-    var querystring = url.substring(url.indexOf('q='))
+    var querystring = url.substring(url.indexOf('/issues'))
+
+    // filter object stores the querystring, the organization and the repo
+    var filter = {
+      filter: querystring,
+      organization: urlObj.organization,
+      currentRepo: urlObj.currentRepo
+    }
 
     chrome.storage.sync.get({
-      filters: ''
+      filters: []
     }, (item) => {
-      if (item.filters !== querystring) {
+      
+      var exists = false;
+      var changed = false;
+
+      item.filters.forEach((f) => {
+        // if the storage array contains the org and repo, then set exists flag
+        if (f.organization === filter.organization && f.currentRepo === filter.currentRepo) {
+          exists = true
+
+          // if the querystring value has changed, set the changed flag and update the filter
+          if(f.filter !== filter.filter) {
+            changed = true
+            f.filter = filter.filter
+          }
+        }
+      })
+
+      // if the filter doesn't exist, push to the array and set changed
+      if (!exists) {
+        changed = true
+        item.filters.push(filter)
+      }
+
+      // only save if changed, otherwise the max quota per minute will be exceeded throwing errors
+      if (changed) {
         chrome.storage.sync.set({
-          filters: querystring
+          filters: item.filters
         }, () => { console.log('filters saved') })
       }
     })
@@ -269,8 +301,8 @@ function addRepoToList(repoFullName, repo) {
 function populateUrlMetadata() {
   var url = document.location.href
   const urlArray = url.split('/')
-  const currentRepo = urlArray[urlArray.length - 3]
-  const organization = urlArray[urlArray.length - 4]
+  const currentRepo = urlArray[4]
+  const organization = urlArray[3]
   const issueNumber = urlArray[urlArray.length - 1].replace('#', '')
 
   const urlObject = {

--- a/background.js
+++ b/background.js
@@ -27,11 +27,22 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         if (item.goToList) {
             // if user setting is set, open issue list and set focus and open cloned issue in tab
             chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
+
+                // find the appropriate filter based on the org and repo
+                var f = item.filters.filter((i) => {
+                    return i.organization === request.organization && i.currentRepo === request.oldRepo
+                })
+
+                var filter = ''
+                if(f && f.length > 0) {
+                    filter = f[0]
+                }
+
                 setTimeout(() => {
                     if(item.createTab) {
                         chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: false })
                     }
-                    chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + '/issues?' + item.filters, selected: true })
+                    chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + filter.filter, selected: true })
                 }, 1000)
             })
         }


### PR DESCRIPTION
- filtering now supports storing filters by organization and repo
- whenever the filter changes, the org,repo and filter are stored in an array
- once Kamino clones an issue, it looks for the correct filter and applies it before navigating back.