### PR TITLE
Chore(Prettier): configured prettier and ran codebase through it

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 var token = ''
 
 // the backdrop
-var backdrop = $('<div class="kamino-backdrop fade in"></div>');
+var backdrop = $('<div class="kamino-backdrop fade in"></div>')
 
 // repo list
 var repoList = []
@@ -10,7 +10,9 @@ var repoList = []
 if (token === '') {
   // load jquery via JS
   $.getScript('https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.0/jquery.min.js', () => {
-    setInterval(() => { initializeExtension() }, 1000)
+    setInterval(() => {
+      initializeExtension()
+    }, 1000)
   })
 }
 
@@ -21,11 +23,14 @@ function initializeExtension() {
   }
 
   // the button
-  const newBtn = $(Handlebars.templates.button().replace(/(\r\n|\n|\r)/gm,""))
+  const newBtn = $(Handlebars.templates.button().replace(/(\r\n|\n|\r)/gm, ''))
 
   // the modal
-  const context = {confirmText: 'Are you sure you want to clone this issue to another repository? Choose whether to clone and close or clone and keep the original issue open.'}
-  const popup = $(Handlebars.templates.modal(context).replace(/(\r\n|\n|\r)/gm,""))
+  const context = {
+    confirmText:
+      'Are you sure you want to clone this issue to another repository? Choose whether to clone and close or clone and keep the original issue open.'
+  }
+  const popup = $(Handlebars.templates.modal(context).replace(/(\r\n|\n|\r)/gm, ''))
 
   // get url
   const urlObj = populateUrlMetadata()
@@ -33,11 +38,12 @@ function initializeExtension() {
   // if the page is not a pull request page(view or create)
   // and the page is not a new issue page
   // and there is no Kamino button in the DOM, proceed
-  if (urlObj.url.indexOf(urlObj.organization + '/' + urlObj.currentRepo + '/compare/') < 0 &&
+  if (
+    urlObj.url.indexOf(urlObj.organization + '/' + urlObj.currentRepo + '/compare/') < 0 &&
     urlObj.url.indexOf(urlObj.organization + '/' + urlObj.currentRepo + '/pull/') < 0 &&
     urlObj.url.indexOf(urlObj.organization + '/' + urlObj.currentRepo + '/issues/new') < 0 &&
-    $('.kaminoButton').length === 0) {
-
+    $('.kaminoButton').length === 0
+  ) {
     // look for any applied issue filters
     saveAppliedFilters(urlObj)
 
@@ -46,18 +52,21 @@ function initializeExtension() {
     $(popup).insertBefore($('.sidebar-assignee'))
 
     // remove the open class just to be sure
-    $('.btn-group').removeClass('open');
+    $('.btn-group').removeClass('open')
 
     // load the token
-    chrome.storage.sync.get({
-      githubToken: ''
-    }, (item) => {
-      token = item.githubToken
-      // grab the PAT
-      if ($('.kaminoButton').length > 0) {
-        loadRepos()
+    chrome.storage.sync.get(
+      {
+        githubToken: ''
+      },
+      (item) => {
+        token = item.githubToken
+        // grab the PAT
+        if ($('.kaminoButton').length > 0) {
+          loadRepos()
+        }
       }
-    })
+    )
 
     $('.kaminoButton').click(() => {
       // make sure the bootstrap dropdown opens and closes properly
@@ -67,8 +76,7 @@ function initializeExtension() {
     $('.quickClone').click(() => {
       if ($('.quickClone').attr('data-repo') === undefined) {
         openDropdown()
-      }
-      else {
+      } else {
         itemClick($('.quickClone').attr('data-repo'))
       }
     })
@@ -108,44 +116,51 @@ function saveAppliedFilters(urlObj) {
       currentRepo: urlObj.currentRepo
     }
 
-    chrome.storage.sync.get({
-      filters: []
-    }, (item) => {
+    chrome.storage.sync.get(
+      {
+        filters: []
+      },
+      (item) => {
+        var exists = false
+        var changed = false
 
-      var exists = false;
-      var changed = false;
-
-      // convert the string to an empty array for existing users
-      if (typeof item.filters === 'string') {
-        item.filters = []
-      }
-
-      item.filters.forEach((f) => {
-        // if the storage array contains the org and repo, then set exists flag
-        if (f.organization === filter.organization && f.currentRepo === filter.currentRepo) {
-          exists = true
-
-          // if the querystring value has changed, set the changed flag and update the filter
-          if (f.filter !== filter.filter) {
-            changed = true
-            f.filter = filter.filter
-          }
+        // convert the string to an empty array for existing users
+        if (typeof item.filters === 'string') {
+          item.filters = []
         }
-      })
 
-      // if the filter doesn't exist, push to the array and set changed
-      if (!exists) {
-        changed = true
-        item.filters.push(filter)
-      }
+        item.filters.forEach((f) => {
+          // if the storage array contains the org and repo, then set exists flag
+          if (f.organization === filter.organization && f.currentRepo === filter.currentRepo) {
+            exists = true
 
-      // only save if changed, otherwise the max quota per minute will be exceeded throwing errors
-      if (changed) {
-        chrome.storage.sync.set({
-          filters: item.filters
-        }, () => { console.log('filters saved') })
+            // if the querystring value has changed, set the changed flag and update the filter
+            if (f.filter !== filter.filter) {
+              changed = true
+              f.filter = filter.filter
+            }
+          }
+        })
+
+        // if the filter doesn't exist, push to the array and set changed
+        if (!exists) {
+          changed = true
+          item.filters.push(filter)
+        }
+
+        // only save if changed, otherwise the max quota per minute will be exceeded throwing errors
+        if (changed) {
+          chrome.storage.sync.set(
+            {
+              filters: item.filters
+            },
+            () => {
+              console.log('filters saved')
+            }
+          )
+        }
       }
-    })
+    )
   }
 }
 
@@ -166,7 +181,7 @@ function getRepos(url) {
 
       compileRepositoryList(repos.data)
 
-      if(nextLink) {
+      if (nextLink) {
         return getRepos(nextLink)
       } else {
         return null
@@ -179,25 +194,24 @@ function getRepos(url) {
 
 function loadRepos() {
   // wire up search value change events
-  var lastValue = '';
-  $(".repoSearch").on('change keyup paste mouseup', function() {
-      if ($(this).val() != lastValue) {
-          lastValue = $(this).val()
-          searchRepositories(lastValue)
-      }
+  var lastValue = ''
+  $('.repoSearch').on('change keyup paste mouseup', function() {
+    if ($(this).val() != lastValue) {
+      lastValue = $(this).val()
+      searchRepositories(lastValue)
+    }
   })
 
   // create a way to go to options without using the extension context menu
-  $(".kamino-heading").click(() => {
-    chrome.runtime.sendMessage({ action:'goToOptions' }, (response) => {
-    })
+  $('.kamino-heading').click(() => {
+    chrome.runtime.sendMessage({ action: 'goToOptions' }, (response) => {})
   })
 
   // if there's no personal access token, disable the button
   if (token === '') {
     console.log('disabling button because there is no Personal Access Token for authentication with Github')
-    $(".kaminoButton").prop('disabled', true)
-    $(".quickClone").prop('disabled', true)
+    $('.kaminoButton').prop('disabled', true)
+    $('.quickClone').prop('disabled', true)
   }
 
   repoList = []
@@ -210,65 +224,66 @@ function loadRepos() {
   $('.repoDropdown').append('<li class="dropdown-header dropdown-header-used">Last Used</li>')
   $('.repoDropdown').append('<li class="dropdown-header dropdown-header-rest">The Rest</li>')
 
-  getRepos('https://api.github.com/user/repos?per_page=100').then(() => {
-  })
+  getRepos('https://api.github.com/user/repos?per_page=100').then(() => {})
 }
 
 function compileRepositoryList(list, searchTerm) {
-  chrome.storage.sync.get({
-    mostUsed: []
-  }, (item) => {
-    // check for a populated list
-    if (item.mostUsed && item.mostUsed.length > 0) {
-      $('.quickClone').attr('data-repo', item.mostUsed[0]);
-      $('.quickClone').text('Clone to ' + item.mostUsed[0].substring(item.mostUsed[0].indexOf('/') + 1))
+  chrome.storage.sync.get(
+    {
+      mostUsed: []
+    },
+    (item) => {
+      // check for a populated list
+      if (item.mostUsed && item.mostUsed.length > 0) {
+        $('.quickClone').attr('data-repo', item.mostUsed[0])
+        $('.quickClone').text('Clone to ' + item.mostUsed[0].substring(item.mostUsed[0].indexOf('/') + 1))
 
-      // show used separator header
-      $('.dropdown-header-used').addClass('active')
+        // show used separator header
+        $('.dropdown-header-used').addClass('active')
 
-      var mostUsed = item.mostUsed
+        var mostUsed = item.mostUsed
 
-      // filter out most used by search term
-      if(searchTerm && searchTerm !== '') {
-        console.log('filtering most used: ', searchTerm)
-        mostUsed = item.mostUsed.filter((item, index) => {
-          return item.indexOf(searchTerm) > -1
+        // filter out most used by search term
+        if (searchTerm && searchTerm !== '') {
+          console.log('filtering most used: ', searchTerm)
+          mostUsed = item.mostUsed.filter((item, index) => {
+            return item.indexOf(searchTerm) > -1
+          })
+        }
+
+        // hide header if there are no last used items
+        if (!mostUsed || mostUsed.length === 0) {
+          $('.dropdown-header-used').removeClass('active')
+        }
+
+        mostUsed.forEach((repoFull) => {
+          // remove organization
+          var repo = repoFull.substring(repoFull.indexOf('/') + 1)
+
+          addRepoToList(repoFull, repo, 'used')
+
+          // remove the item from the main repos list
+          list = list.filter((i) => {
+            return i.full_name !== repoFull
+          })
         })
-      }
-
-      // hide header if there are no last used items
-      if(!mostUsed || mostUsed.length === 0) {
+      } else {
         $('.dropdown-header-used').removeClass('active')
+        $('.quickClone').text('Clone to')
       }
 
-      mostUsed.forEach((repoFull) => {
-        // remove organization
-        var repo = repoFull.substring(repoFull.indexOf('/') + 1)
+      // show or hide rest header based on number of items
+      if (!list || list.length === 0) {
+        $('.dropdown-header-rest').removeClass('active')
+      } else {
+        $('.dropdown-header-rest').addClass('active')
+      }
 
-        addRepoToList(repoFull, repo, 'used')
-
-        // remove the item from the main repos list
-        list = list.filter((i) => {
-          return i.full_name !== repoFull
-        })
+      list.forEach((repo) => {
+        addRepoToList(repo.full_name, repo.name)
       })
     }
-    else {
-      $('.dropdown-header-used').removeClass('active')
-      $('.quickClone').text('Clone to');
-    }
-
-    // show or hide rest header based on number of items
-    if(!list || list.length === 0) {
-      $('.dropdown-header-rest').removeClass('active')
-    } else {
-      $('.dropdown-header-rest').addClass('active')
-    }
-
-    list.forEach((repo) => {
-      addRepoToList(repo.full_name, repo.name);
-    })
-  })
+  )
 }
 
 function searchRepositories(searchTerm) {
@@ -289,11 +304,29 @@ function searchRepositories(searchTerm) {
 function getGithubIssue(repo, closeOriginal) {
   const urlObj = populateUrlMetadata()
 
-  ajaxRequest('GET', '', 'https://api.github.com/repos/' + urlObj.organization + '/' + urlObj.currentRepo + '/issues/' + urlObj.issueNumber).then((issue) => {
+  ajaxRequest(
+    'GET',
+    '',
+    'https://api.github.com/repos/' + urlObj.organization + '/' + urlObj.currentRepo + '/issues/' + urlObj.issueNumber
+  ).then((issue) => {
     // build new issue
     const newIssue = {
       title: issue.data.title,
-      body: 'From ' + urlObj.currentRepo + ' created by [' + issue.data.user.login + '](' + issue.data.user.html_url + ') : ' + urlObj.organization + '/' + urlObj.currentRepo + '#' + urlObj.issueNumber + "  \n\n" + issue.data.body,
+      body:
+        'From ' +
+        urlObj.currentRepo +
+        ' created by [' +
+        issue.data.user.login +
+        '](' +
+        issue.data.user.html_url +
+        ') : ' +
+        urlObj.organization +
+        '/' +
+        urlObj.currentRepo +
+        '#' +
+        urlObj.issueNumber +
+        '  \n\n' +
+        issue.data.body,
       labels: issue.data.labels
     }
 
@@ -316,19 +349,33 @@ function closeGithubIssue(oldIssue) {
 
   const urlObj = populateUrlMetadata()
 
-  ajaxRequest('PATCH', issueToClose, 'https://api.github.com/repos/' + urlObj.organization + '/' + urlObj.currentRepo + '/issues/' + urlObj.issueNumber).then((done) => {
-  })
+  ajaxRequest(
+    'PATCH',
+    issueToClose,
+    'https://api.github.com/repos/' + urlObj.organization + '/' + urlObj.currentRepo + '/issues/' + urlObj.issueNumber
+  ).then((done) => {})
 }
 
 function commentOnIssue(repo, oldIssue, newIssue, closeOriginal) {
   const urlObj = populateUrlMetadata()
   const newIssueLink = '[' + repo + ']' + '(' + newIssue.html_url + ')'
   const comment = {
-    body: closeOriginal ? 'Kamino closed and cloned this issue to ' +  newIssueLink: 'Kamino cloned this issue to ' + newIssueLink
+    body: closeOriginal
+      ? 'Kamino closed and cloned this issue to ' + newIssueLink
+      : 'Kamino cloned this issue to ' + newIssueLink
   }
 
-  ajaxRequest('POST', comment, 'https://api.github.com/repos/' + urlObj.organization + '/' + urlObj.currentRepo + '/issues/' + urlObj.issueNumber + '/comments').then((response) => {
-
+  ajaxRequest(
+    'POST',
+    comment,
+    'https://api.github.com/repos/' +
+      urlObj.organization +
+      '/' +
+      urlObj.currentRepo +
+      '/issues/' +
+      urlObj.issueNumber +
+      '/comments'
+  ).then((response) => {
     if (closeOriginal) {
       // if success, close the existing issue and open new in a new tab
       closeGithubIssue(oldIssue)
@@ -339,32 +386,37 @@ function commentOnIssue(repo, oldIssue, newIssue, closeOriginal) {
 
 function goToIssueList(repo, issueNumber, org, oldRepo) {
   // based on user settings, determines if the issues list will open after a clone or not
-  chrome.runtime.sendMessage({ repo: repo, issueNumber: issueNumber, organization: org, oldRepo: oldRepo }, (response) => {
-  })
+  chrome.runtime.sendMessage(
+    { repo: repo, issueNumber: issueNumber, organization: org, oldRepo: oldRepo },
+    (response) => {}
+  )
 }
 
 function ajaxRequest(type, data, url) {
   return new Promise((resolve, reject) => {
-    chrome.storage.sync.get({
-      githubToken: ''
-    }, (item) => {
-      token = item.githubToken
-      $.ajax({
-        type: type,
-        beforeSend: (request) => {
-          request.setRequestHeader('Authorization', 'token ' + token)
-          request.setRequestHeader('Content-Type', 'application/json')
-        },
-        data: JSON.stringify(data),
-        url: url
-      }).done((data, status, header) => {
-        resolve({
-          data: data,
-          status: status,
-          header: header
+    chrome.storage.sync.get(
+      {
+        githubToken: ''
+      },
+      (item) => {
+        token = item.githubToken
+        $.ajax({
+          type: type,
+          beforeSend: (request) => {
+            request.setRequestHeader('Authorization', 'token ' + token)
+            request.setRequestHeader('Content-Type', 'application/json')
+          },
+          data: JSON.stringify(data),
+          url: url
+        }).done((data, status, header) => {
+          resolve({
+            data: data,
+            status: status,
+            header: header
+          })
         })
-      })
-    })
+      }
+    )
   })
 }
 
@@ -373,15 +425,29 @@ function addRepoToList(repoFullName, repo, section) {
   const periodReplace = repo.replace(/\./g, '_')
 
   // determine where the item needs to go
-  if(section === 'used') {
-    if($('#' + periodReplace).length === 0) {
-      $('.dropdown-header-rest').before('<li data-toggle="modal" id="' + periodReplace + '" data-target="#kaminoModal"><a class="repoItem" href="#">' + repoFullName + '</a></li>')
+  if (section === 'used') {
+    if ($('#' + periodReplace).length === 0) {
+      $('.dropdown-header-rest').before(
+        '<li data-toggle="modal" id="' +
+          periodReplace +
+          '" data-target="#kaminoModal"><a class="repoItem" href="#">' +
+          repoFullName +
+          '</a></li>'
+      )
     }
   } else {
-    $('.repoDropdown').append('<li data-toggle="modal" id="' + periodReplace + '" data-target="#kaminoModal"><a class="repoItem" href="#">' + repoFullName + '</a></li>')
+    $('.repoDropdown').append(
+      '<li data-toggle="modal" id="' +
+        periodReplace +
+        '" data-target="#kaminoModal"><a class="repoItem" href="#">' +
+        repoFullName +
+        '</a></li>'
+    )
   }
 
-  $('#' + periodReplace).bind('click', () => { itemClick(repoFullName) })
+  $('#' + periodReplace).bind('click', () => {
+    itemClick(repoFullName)
+  })
 }
 
 function populateUrlMetadata() {
@@ -403,49 +469,55 @@ function populateUrlMetadata() {
 
 function addToMostUsed(repo) {
   // get
-  chrome.storage.sync.get({
-    mostUsed: []
-  }, (item) => {
-    // find the item
-    if (item.mostUsed.find((e) => { return e === repo }) !== undefined) {
-      // if exists, get index
-      var index = item.mostUsed.indexOf(repo);
+  chrome.storage.sync.get(
+    {
+      mostUsed: []
+    },
+    (item) => {
+      // find the item
+      if (
+        item.mostUsed.find((e) => {
+          return e === repo
+        }) !== undefined
+      ) {
+        // if exists, get index
+        var index = item.mostUsed.indexOf(repo)
 
-      // remove
-      item.mostUsed.splice(index, 1)
+        // remove
+        item.mostUsed.splice(index, 1)
 
-      // add to top
-      item.mostUsed.unshift(repo)
+        // add to top
+        item.mostUsed.unshift(repo)
 
-      // pop the last if item count is more than 5
-      if (item.mostUsed.length > 5) {
-        item.mostUsed.pop()
+        // pop the last if item count is more than 5
+        if (item.mostUsed.length > 5) {
+          item.mostUsed.pop()
+        }
+      } else {
+        // add to top
+        item.mostUsed.unshift(repo)
+
+        // pop the last if item count is more than 5
+        if (item.mostUsed.length > 5) {
+          item.mostUsed.pop()
+        }
       }
+
+      // save
+      chrome.storage.sync.set(
+        {
+          mostUsed: item.mostUsed
+        },
+        (done) => {}
+      )
     }
-    else {
-      // add to top
-      item.mostUsed.unshift(repo)
-
-      // pop the last if item count is more than 5
-      if (item.mostUsed.length > 5) {
-        item.mostUsed.pop()
-      }
-    }
-
-    // save
-    chrome.storage.sync.set({
-      mostUsed: item.mostUsed
-    }, (done) => {
-
-    })
-  })
+  )
 }
 
 function openDropdown() {
   if ($('.btn-group').hasClass('open')) {
     $('.btn-group').removeClass('open')
-  }
-  else {
+  } else {
     $('.btn-group').addClass('open')
   }
 }
@@ -456,13 +528,17 @@ function itemClick(repo) {
 
   $('.cloneAndClose').attr('data-repo', repo)
   $('.cloneAndKeepOpen').attr('data-repo', repo)
-  $('.confirmText').text('Are you sure you want to clone this issue to ' + repo + '? Choose whether to clone and close or clone and keep the original issue open.')
+  $('.confirmText').text(
+    'Are you sure you want to clone this issue to ' +
+      repo +
+      '? Choose whether to clone and close or clone and keep the original issue open.'
+  )
   openModal()
 }
 
 function closeModal() {
   // make sure the modal closes properly
-  $('.kamino-backdrop').remove();
+  $('.kamino-backdrop').remove()
   $('#kaminoModal').removeClass('in')
   $('#kaminoModal').css('display', '')
 }
@@ -470,5 +546,5 @@ function closeModal() {
 function openModal() {
   $('#kaminoModal').addClass('in')
   $('#kaminoModal').css('display', 'block')
-  $('#js-repo-pjax-container').append(backdrop);
+  $('#js-repo-pjax-container').append(backdrop)
 }

--- a/background.js
+++ b/background.js
@@ -1,66 +1,78 @@
 // used when Github uses push state.
 chrome.webNavigation.onHistoryStateUpdated.addListener((details) => {
-    chrome.tabs.executeScript(null, { file: "jquery/jquery-3.2.0.min.js", runAt: 'document_end' }, (j) => {
-        chrome.tabs.executeScript(null, { file: "handlebars.runtime-v4.0.10.js", runAt: 'document_end' }, (h) => {
-            chrome.tabs.executeScript(null, { file: "template.js", runAt: 'document_end' }, (h) => {
-                chrome.tabs.executeScript(null, { file: "app.js", runAt: 'document_end' }, (a) => {
-                    chrome.tabs.insertCSS(null, { file: "css/style.css", runAt: 'document_end' });
-                });
-            })
+  chrome.tabs.executeScript(null, { file: 'jquery/jquery-3.2.0.min.js', runAt: 'document_end' }, (j) => {
+    chrome.tabs.executeScript(null, { file: 'handlebars.runtime-v4.0.10.js', runAt: 'document_end' }, (h) => {
+      chrome.tabs.executeScript(null, { file: 'template.js', runAt: 'document_end' }, (h) => {
+        chrome.tabs.executeScript(null, { file: 'app.js', runAt: 'document_end' }, (a) => {
+          chrome.tabs.insertCSS(null, { file: 'css/style.css', runAt: 'document_end' })
         })
+      })
     })
+  })
 })
 
 // open the Kamino Github page on installed
 chrome.runtime.onInstalled.addListener((details) => {
-    if (details.reason === 'installed') {
-        chrome.tabs.create({ url: 'https://github.com/gatewayapps/kamino' }, (tab) => {
-            console.log("Kamino Github page launched")
-        })
-    }
+  if (details.reason === 'installed') {
+    chrome.tabs.create({ url: 'https://github.com/gatewayapps/kamino' }, (tab) => {
+      console.log('Kamino Github page launched')
+    })
+  }
 })
 
 // listen for tab change requests
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    if(request.action && request.action === 'goToOptions') {
-        // open the options screen in a new tab
-        chrome.tabs.create({ url: 'chrome-extension://' + chrome.runtime.id + '/options.html', selected: true })
-    } else {
-        // get settings
-        chrome.storage.sync.get({
-            goToList: false,
-            createTab: true,
-            filters: ''
-        }, (item) => {
-            if (item.goToList) {
-                // if user setting is set, open issue list and set focus and open cloned issue in tab
-                chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
+  if (request.action && request.action === 'goToOptions') {
+    // open the options screen in a new tab
+    chrome.tabs.create({ url: 'chrome-extension://' + chrome.runtime.id + '/options.html', selected: true })
+  } else {
+    // get settings
+    chrome.storage.sync.get(
+      {
+        goToList: false,
+        createTab: true,
+        filters: ''
+      },
+      (item) => {
+        if (item.goToList) {
+          // if user setting is set, open issue list and set focus and open cloned issue in tab
+          chrome.tabs.query({ currentWindow: true, active: true }, (tabs) => {
+            // find the appropriate filter based on the org and repo
+            var f = item.filters.filter((i) => {
+              return i.organization === request.organization && i.currentRepo === request.oldRepo
+            })
 
-                    // find the appropriate filter based on the org and repo
-                    var f = item.filters.filter((i) => {
-                        return i.organization === request.organization && i.currentRepo === request.oldRepo
-                    })
+            var filter = ''
+            if (f && f.length > 0) {
+              filter = f[0]
+            }
 
-                    var filter = ''
-                    if (f && f.length > 0) {
-                        filter = f[0]
-                    }
-
-                    setTimeout(() => {
-                        if (item.createTab) {
-                            chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: false })
-                        }
-                        chrome.tabs.update(tabs[0].id, { url: 'https://github.com/' + request.organization + '/' + request.oldRepo + filter.filter, selected: true })
-                    }, 1000)
+            setTimeout(() => {
+              if (item.createTab) {
+                chrome.tabs.create({
+                  url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber,
+                  selected: false
                 })
-            }
-            else {
-                console.log('no navigation')
-                if (item.createTab) {
-                    // if user setting is not set, open open cloned issue in new tab and set focus to that tab
-                    setTimeout(() => { chrome.tabs.create({ url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber, selected: true }) }, 1000)
-                }
-            }
-        })
-    }
+              }
+              chrome.tabs.update(tabs[0].id, {
+                url: 'https://github.com/' + request.organization + '/' + request.oldRepo + filter.filter,
+                selected: true
+              })
+            }, 1000)
+          })
+        } else {
+          console.log('no navigation')
+          if (item.createTab) {
+            // if user setting is not set, open open cloned issue in new tab and set focus to that tab
+            setTimeout(() => {
+              chrome.tabs.create({
+                url: 'https://github.com/' + request.repo + '/issues/' + request.issueNumber,
+                selected: true
+              })
+            }, 1000)
+          }
+        }
+      }
+    )
+  }
 })

--- a/backgroundScriptsAPIBridge.js
+++ b/backgroundScriptsAPIBridge.js
@@ -1,846 +1,1184 @@
-if (!Range.prototype["intersectsNode"]) {
-    Range.prototype["intersectsNode"] = function (node) {
-        let range = document.createRange();
-        range.selectNode(node);
-        return 0 > this.compareBoundaryPoints(Range.END_TO_START, range)
-            && 0 < this.compareBoundaryPoints(Range.START_TO_END, range);
-    };
+if (!Range.prototype['intersectsNode']) {
+  Range.prototype['intersectsNode'] = function(node) {
+    let range = document.createRange()
+    range.selectNode(node)
+    return (
+      0 > this.compareBoundaryPoints(Range.END_TO_START, range) &&
+      0 < this.compareBoundaryPoints(Range.START_TO_END, range)
+    )
+  }
 }
-var getExtensionProtocol = function () {
-    if (typeof browser == "undefined") {
-        if (typeof chrome !== "undefined")
-            return "chrome-extension://";
-    }
-    else {
-        return "ms-browser-extension://";
-    }
-};
+var getExtensionProtocol = function() {
+  if (typeof browser == 'undefined') {
+    if (typeof chrome !== 'undefined') return 'chrome-extension://'
+  } else {
+    return 'ms-browser-extension://'
+  }
+}
 class FakeEvent {
-    addListener(callback) { }
-    addRules(rules, callback) { }
-    getRules(ruleIdentifiers, callback) { }
-    hasListener(callback) { return false; }
-    hasListeners() { return false; }
-    removeRules(ruleIdentifiers, callback) { }
-    removeListener(callback) { }
+  addListener(callback) {}
+  addRules(rules, callback) {}
+  getRules(ruleIdentifiers, callback) {}
+  hasListener(callback) {
+    return false
+  }
+  hasListeners() {
+    return false
+  }
+  removeRules(ruleIdentifiers, callback) {}
+  removeListener(callback) {}
 }
 class EdgeBridgeHelper {
-    constructor() {
-        this.fakeEvent = new FakeEvent();
+  constructor() {
+    this.fakeEvent = new FakeEvent()
+  }
+  toAbsolutePath(relativePath) {
+    if (relativePath.indexOf('ms-browser-extension://') == 0) {
+      return relativePath.replace(myBrowser.runtime.getURL(''), '')
+    } else if (relativePath.indexOf('/') != 0) {
+      var absolutePath = ''
+      var documentPath = document.location.pathname
+      absolutePath = documentPath.substring(0, documentPath.lastIndexOf('/') + 1)
+      absolutePath += relativePath
+      return absolutePath
     }
-    toAbsolutePath(relativePath) {
-        if (relativePath.indexOf("ms-browser-extension://") == 0) {
-            return relativePath.replace(myBrowser.runtime.getURL(""), "");
-        }
-        else if (relativePath.indexOf("/") != 0) {
-            var absolutePath = "";
-            var documentPath = document.location.pathname;
-            absolutePath = documentPath.substring(0, documentPath.lastIndexOf("/") + 1);
-            absolutePath += relativePath;
-            return absolutePath;
-        }
-        return relativePath;
-    }
+    return relativePath
+  }
 }
-var bridgeHelper = new EdgeBridgeHelper();
+var bridgeHelper = new EdgeBridgeHelper()
 class EdgeBridgeDebugLog {
-    constructor() {
-        this.CatchOnException = true;
-        this.VerboseLogging = true;
-        this.FailedCalls = {};
-        this.SuccededCalls = {};
-        this.DeprecatedCalls = {};
-        this.BridgedCalls = {};
-        this.UnavailableApis = {};
-        this.EdgeIssues = {};
+  constructor() {
+    this.CatchOnException = true
+    this.VerboseLogging = true
+    this.FailedCalls = {}
+    this.SuccededCalls = {}
+    this.DeprecatedCalls = {}
+    this.BridgedCalls = {}
+    this.UnavailableApis = {}
+    this.EdgeIssues = {}
+  }
+  log(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.log(message)
+      }
+    } catch (e) {}
+  }
+  info(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.info(message)
+      }
+    } catch (e) {}
+  }
+  warn(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.warn(message)
+      }
+    } catch (e) {}
+  }
+  error(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.error(message)
+      }
+    } catch (e) {}
+  }
+  DoActionAndLog(action, name, deprecatedTo, bridgedTo) {
+    var result
+    try {
+      result = action()
+      this.AddToCalledDictionary(this.SuccededCalls, name)
+      if (typeof deprecatedTo !== 'undefined' && typeof deprecatedTo !== 'null') {
+        this.warn('API Call Deprecated - Name: ' + name + ', Please use ' + deprecatedTo + ' instead!')
+        this.AddToCalledDictionary(this.DeprecatedCalls, name)
+      }
+      if (typeof bridgedTo !== 'undefined' && typeof bridgedTo !== 'null') {
+        this.info("API Call '" + name + "' has been bridged to another Edge API: " + bridgedTo)
+        this.AddToCalledDictionary(this.BridgedCalls, name)
+      }
+      return result
+    } catch (ex) {
+      this.AddToCalledDictionary(this.FailedCalls, name)
+      if (this.CatchOnException) this.error('API Call Failed: ' + name + ' - ' + ex)
+      else throw ex
     }
-    log(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.log(message);
-            }
-        }
-        catch (e) {
-        }
+  }
+  LogEdgeIssue(name, message) {
+    this.warn(message)
+    this.AddToCalledDictionary(this.EdgeIssues, name)
+  }
+  LogUnavailbleApi(name, deprecatedTo) {
+    this.warn("API Call '" + name + "' is not supported in Edge")
+    this.AddToCalledDictionary(this.UnavailableApis, name)
+    if (typeof deprecatedTo !== 'undefined' && typeof deprecatedTo !== 'null') {
+      this.warn('API Call Deprecated - Name: ' + name + ', Please use ' + deprecatedTo + ' instead!')
+      this.AddToCalledDictionary(this.DeprecatedCalls, name)
     }
-    info(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.info(message);
-            }
-        }
-        catch (e) {
-        }
+  }
+  AddToCalledDictionary(dictionary, name) {
+    if (typeof dictionary[name] !== 'undefined') {
+      dictionary[name]++
+    } else {
+      dictionary[name] = 1
     }
-    warn(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.warn(message);
-            }
-        }
-        catch (e) {
-        }
-    }
-    error(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.error(message);
-            }
-        }
-        catch (e) {
-        }
-    }
-    DoActionAndLog(action, name, deprecatedTo, bridgedTo) {
-        var result;
-        try {
-            result = action();
-            this.AddToCalledDictionary(this.SuccededCalls, name);
-            if (typeof deprecatedTo !== "undefined" && typeof deprecatedTo !== "null") {
-                this.warn("API Call Deprecated - Name: " + name + ", Please use " + deprecatedTo + " instead!");
-                this.AddToCalledDictionary(this.DeprecatedCalls, name);
-            }
-            if (typeof bridgedTo !== "undefined" && typeof bridgedTo !== "null") {
-                this.info("API Call '" + name + "' has been bridged to another Edge API: " + bridgedTo);
-                this.AddToCalledDictionary(this.BridgedCalls, name);
-            }
-            return result;
-        }
-        catch (ex) {
-            this.AddToCalledDictionary(this.FailedCalls, name);
-            if (this.CatchOnException)
-                this.error("API Call Failed: " + name + " - " + ex);
-            else
-                throw ex;
-        }
-    }
-    LogEdgeIssue(name, message) {
-        this.warn(message);
-        this.AddToCalledDictionary(this.EdgeIssues, name);
-    }
-    LogUnavailbleApi(name, deprecatedTo) {
-        this.warn("API Call '" + name + "' is not supported in Edge");
-        this.AddToCalledDictionary(this.UnavailableApis, name);
-        if (typeof deprecatedTo !== "undefined" && typeof deprecatedTo !== "null") {
-            this.warn("API Call Deprecated - Name: " + name + ", Please use " + deprecatedTo + " instead!");
-            this.AddToCalledDictionary(this.DeprecatedCalls, name);
-        }
-    }
-    AddToCalledDictionary(dictionary, name) {
-        if (typeof dictionary[name] !== "undefined") {
-            dictionary[name]++;
-        }
-        else {
-            dictionary[name] = 1;
-        }
-    }
+  }
 }
-var bridgeLog = new EdgeBridgeDebugLog();
+var bridgeLog = new EdgeBridgeDebugLog()
 class EdgeChromeAppBridge {
-    getDetails() {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeChromeRuntimeBridge.prototype.getManifest();
-        }, "app.getManifest", undefined, "runtime.getManifest");
-    }
-    get isInstalled() { return bridgeLog.DoActionAndLog(() => { throw "app.isInstalled is not available in Edge"; }, "app.isInstalled"); }
-    getIsInstalled() { return bridgeLog.DoActionAndLog(() => { throw "app.getIsInstalled is not available in the Edge"; }, "app.getIsInstalled"); }
-    installState() { return bridgeLog.DoActionAndLog(() => { throw "app.installState is not available in Edge"; }, "app.installState"); }
-    runningState() { return bridgeLog.DoActionAndLog(() => { throw "app.runningState is not available in Edge"; }, "app.runningState"); }
+  getDetails() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeChromeRuntimeBridge.prototype.getManifest()
+      },
+      'app.getManifest',
+      undefined,
+      'runtime.getManifest'
+    )
+  }
+  get isInstalled() {
+    return bridgeLog.DoActionAndLog(() => {
+      throw 'app.isInstalled is not available in Edge'
+    }, 'app.isInstalled')
+  }
+  getIsInstalled() {
+    return bridgeLog.DoActionAndLog(() => {
+      throw 'app.getIsInstalled is not available in the Edge'
+    }, 'app.getIsInstalled')
+  }
+  installState() {
+    return bridgeLog.DoActionAndLog(() => {
+      throw 'app.installState is not available in Edge'
+    }, 'app.installState')
+  }
+  runningState() {
+    return bridgeLog.DoActionAndLog(() => {
+      throw 'app.runningState is not available in Edge'
+    }, 'app.runningState')
+  }
 }
 class EdgeBrowserActionBridge {
-    get onClicked() { return bridgeLog.DoActionAndLog(() => { return myBrowser.browserAction.onClicked; }, "browserAction.onClicked"); }
-    disable(tabId) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.browserAction.disable(tabId);
-        }, "browserAction.disable");
-    }
-    enable(tabId) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof tabId !== "undefined" && typeof tabId !== "null") {
-                myBrowser.browserAction.enable(tabId);
+  get onClicked() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.browserAction.onClicked
+    }, 'browserAction.onClicked')
+  }
+  disable(tabId) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.browserAction.disable(tabId)
+    }, 'browserAction.disable')
+  }
+  enable(tabId) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof tabId !== 'undefined' && typeof tabId !== 'null') {
+        myBrowser.browserAction.enable(tabId)
+      } else {
+        myBrowser.browserAction.enable()
+      }
+    }, 'browserAction.Enable')
+  }
+  getBadgeBackgroundColor(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.browserAction.getBadgeBackgroundColor(details, callback)
+    }, 'browserAction.getBadgeBackgroundColor')
+  }
+  getBadgeText(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.browserAction.getBadgeText(details, callback)
+    }, 'browserAction.getBadgeText')
+  }
+  setBadgeBackgroundColor(details) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.browserAction.setBadgeBackgroundColor(details)
+    }, 'browserAction.setBadgeBackgroundColor')
+  }
+  setBadgeText(details) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.browserAction.setBadgeText(details)
+    }, 'browserAction.setBadgeText')
+  }
+  setIcon(details, callback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        if (typeof details.path !== 'undefined') {
+          if (typeof details.path === 'object') {
+            for (var key in details.path) {
+              if (details.path.hasOwnProperty(key)) {
+                details.path[key] = bridgeHelper.toAbsolutePath(details.path[key])
+              }
             }
-            else {
-                myBrowser.browserAction.enable();
-            }
-        }, "browserAction.Enable");
-    }
-    getBadgeBackgroundColor(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.browserAction.getBadgeBackgroundColor(details, callback);
-        }, "browserAction.getBadgeBackgroundColor");
-    }
-    getBadgeText(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.browserAction.getBadgeText(details, callback);
-        }, "browserAction.getBadgeText");
-    }
-    setBadgeBackgroundColor(details) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.browserAction.setBadgeBackgroundColor(details);
-        }, "browserAction.setBadgeBackgroundColor");
-    }
-    setBadgeText(details) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.browserAction.setBadgeText(details);
-        }, "browserAction.setBadgeText");
-    }
-    setIcon(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof details.path !== "undefined") {
-                if (typeof details.path === "object") {
-                    for (var key in details.path) {
-                        if (details.path.hasOwnProperty(key)) {
-                            details.path[key] = bridgeHelper.toAbsolutePath(details.path[key]);
-                        }
-                    }
-                }
-                else {
-                    details.path = bridgeHelper.toAbsolutePath(details.path);
-                }
-            }
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.browserAction.setIcon(details, callback);
-            }
-            else {
-                myBrowser.browserAction.setIcon(details);
-            }
-        }, "browserAction.setIcon", undefined, "browserAction.setIcon with absolute path");
-    }
-    setPopup(details) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.browserAction.setPopup(details);
-        }, "browserAction.setPopup");
-    }
+          } else {
+            details.path = bridgeHelper.toAbsolutePath(details.path)
+          }
+        }
+        if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+          myBrowser.browserAction.setIcon(details, callback)
+        } else {
+          myBrowser.browserAction.setIcon(details)
+        }
+      },
+      'browserAction.setIcon',
+      undefined,
+      'browserAction.setIcon with absolute path'
+    )
+  }
+  setPopup(details) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.browserAction.setPopup(details)
+    }, 'browserAction.setPopup')
+  }
 }
 class EdgeChromeBrowserActionBridge extends EdgeBrowserActionBridge {
-    getPopup(details, callback) {
-        bridgeLog.LogUnavailbleApi("browserAction.getPopup");
-    }
-    getTitle(details, callback) {
-        bridgeLog.LogUnavailbleApi("browserAction.getTitle");
-    }
-    setTitle(details) {
-        bridgeLog.LogUnavailbleApi("browserAction.setTitle");
-    }
+  getPopup(details, callback) {
+    bridgeLog.LogUnavailbleApi('browserAction.getPopup')
+  }
+  getTitle(details, callback) {
+    bridgeLog.LogUnavailbleApi('browserAction.getTitle')
+  }
+  setTitle(details) {
+    bridgeLog.LogUnavailbleApi('browserAction.setTitle')
+  }
 }
 class EdgeContextMenusBridge {
-    get ACTION_MENU_TOP_LEVEL_LIMIT() { return bridgeLog.DoActionAndLog(() => { return myBrowser.contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT; }, "contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT"); }
-    get onClicked() { return bridgeLog.DoActionAndLog(() => { return myBrowser.contextMenus.onClicked; }, "contextMenus.onClicked"); }
-    create(createProperties, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.contextMenus.create(createProperties, callback);
-            }
-            else {
-                myBrowser.contextMenus.create(createProperties);
-            }
-        }, "contextMenus.create");
-    }
-    remove(menuItemId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.contextMenus.remove(menuItemId, callback);
-            }
-            else {
-                myBrowser.contextMenus.remove(menuItemId);
-            }
-        }, "contextMenus.remove");
-    }
-    removeAll(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.contextMenus.removeAll(callback);
-            }
-            else {
-                myBrowser.contextMenus.removeAll();
-            }
-        }, "contextMenus.removeAll");
-    }
-    update(id, updateProperties, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.contextMenus.update(id, updateProperties, callback);
-            }
-            else {
-                myBrowser.contextMenus.update(id, updateProperties);
-            }
-        }, "contextMenus.update");
-    }
+  get ACTION_MENU_TOP_LEVEL_LIMIT() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT
+    }, 'contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT')
+  }
+  get onClicked() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.contextMenus.onClicked
+    }, 'contextMenus.onClicked')
+  }
+  create(createProperties, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.contextMenus.create(createProperties, callback)
+      } else {
+        myBrowser.contextMenus.create(createProperties)
+      }
+    }, 'contextMenus.create')
+  }
+  remove(menuItemId, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.contextMenus.remove(menuItemId, callback)
+      } else {
+        myBrowser.contextMenus.remove(menuItemId)
+      }
+    }, 'contextMenus.remove')
+  }
+  removeAll(callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.contextMenus.removeAll(callback)
+      } else {
+        myBrowser.contextMenus.removeAll()
+      }
+    }, 'contextMenus.removeAll')
+  }
+  update(id, updateProperties, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.contextMenus.update(id, updateProperties, callback)
+      } else {
+        myBrowser.contextMenus.update(id, updateProperties)
+      }
+    }, 'contextMenus.update')
+  }
 }
 class EdgeCookiesBridge {
-    get(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.cookies.get(details, callback);
-        }, "cookies.get");
-    }
-    getAll(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.cookies.getAll(details, callback);
-        }, "cookies.getAll");
-    }
-    remove(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.cookies.remove(details, callback);
-            }
-            else {
-                myBrowser.cookies.remove(details);
-            }
-        }, "cookies.remove");
-    }
-    set(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.cookies.set(details, callback);
-            }
-            else {
-                myBrowser.cookies.set(details);
-            }
-        }, "cookies.set");
-    }
+  get(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.cookies.get(details, callback)
+    }, 'cookies.get')
+  }
+  getAll(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.cookies.getAll(details, callback)
+    }, 'cookies.getAll')
+  }
+  remove(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.cookies.remove(details, callback)
+      } else {
+        myBrowser.cookies.remove(details)
+      }
+    }, 'cookies.remove')
+  }
+  set(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.cookies.set(details, callback)
+      } else {
+        myBrowser.cookies.set(details)
+      }
+    }, 'cookies.set')
+  }
 }
 class EdgeChromeCookiesBridge extends EdgeCookiesBridge {
-    get onChanged() { bridgeLog.LogUnavailbleApi("cookies.onChanged"); return bridgeHelper.fakeEvent; }
+  get onChanged() {
+    bridgeLog.LogUnavailbleApi('cookies.onChanged')
+    return bridgeHelper.fakeEvent
+  }
 }
 class EdgeExtensionBridge {
-    getBackgroundPage() {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.extension.getBackgroundPage();
-        }, "extension.getBackgroundPage");
-    }
-    getURL(path) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.extension.getURL(path);
-        }, "extension.getURL");
-    }
-    getViews(fetchProperties) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.extension.getViews(fetchProperties);
-        }, "extension.getViews");
-    }
+  getBackgroundPage() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.extension.getBackgroundPage()
+    }, 'extension.getBackgroundPage')
+  }
+  getURL(path) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.extension.getURL(path)
+    }, 'extension.getURL')
+  }
+  getViews(fetchProperties) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.extension.getViews(fetchProperties)
+    }, 'extension.getViews')
+  }
 }
 class EdgeChromeExtensionBridge extends EdgeExtensionBridge {
-    get onConnect() { return bridgeLog.DoActionAndLog(() => { return EdgeRuntimeBridge.prototype.onConnect; }, "extension.onConnect", "runtime.onConnect", "runtime.onConnect"); }
-    get onMessage() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessage; }, "extension.onMessage", "runtime.onMessage", "runtime.onMessage"); }
-    get onRequest() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessage; }, "extension.onRequest", "runtime.onMessage", "runtime.onMessage"); }
-    get onRequestExternal() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessageExternal; }, "extension.onRequestExternal", "runtime.onMessageExternal", "runtime.onMessageExternal"); }
-    get inIncognitoContext() { return bridgeLog.DoActionAndLog(() => { return myBrowser.extension["inPrivateContext"]; }, "extension.inIncognitoContext", undefined, "extension.inPrivateContext"); }
-    get lastError() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.lastError; }, "extension.lastError", undefined, "runtime.lastError"); }
-    connect(extensionId, connectInfo) {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeRuntimeBridge.prototype.connect(extensionId, connectInfo);
-        }, "extension.connect", "runtime.connect", "runtime.connect");
-    }
-    sendMessage(message, responseCallback) {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeRuntimeBridge.prototype.sendMessage(message, responseCallback, undefined, undefined);
-        }, "extension.sendMessage", "runtime.sendMessage", "runtime.sendMessage");
-    }
-    sendRequest(extensionId, message, options, responseCallback) {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeRuntimeBridge.prototype.sendMessage(extensionId, message, options, responseCallback);
-        }, "extension.sendRequest", "runtime.sendMessage", "runtime.sendMessage");
-    }
-    isAllowedFileSchemeAccess(callback) {
-        bridgeLog.LogUnavailbleApi("extension.isAllowedFileSchemeAccess");
-    }
-    isAllowedIncognitoAccess(callback) {
-        bridgeLog.LogUnavailbleApi("extension.isAllowedIncognitoAccess");
-    }
-    setUpdateUrlData(data) {
-        bridgeLog.LogUnavailbleApi("extension.setUpdateUrlData");
-    }
+  get onConnect() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.onConnect
+      },
+      'extension.onConnect',
+      'runtime.onConnect',
+      'runtime.onConnect'
+    )
+  }
+  get onMessage() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.onMessage
+      },
+      'extension.onMessage',
+      'runtime.onMessage',
+      'runtime.onMessage'
+    )
+  }
+  get onRequest() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.onMessage
+      },
+      'extension.onRequest',
+      'runtime.onMessage',
+      'runtime.onMessage'
+    )
+  }
+  get onRequestExternal() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.onMessageExternal
+      },
+      'extension.onRequestExternal',
+      'runtime.onMessageExternal',
+      'runtime.onMessageExternal'
+    )
+  }
+  get inIncognitoContext() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.extension['inPrivateContext']
+      },
+      'extension.inIncognitoContext',
+      undefined,
+      'extension.inPrivateContext'
+    )
+  }
+  get lastError() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.lastError
+      },
+      'extension.lastError',
+      undefined,
+      'runtime.lastError'
+    )
+  }
+  connect(extensionId, connectInfo) {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.connect(
+          extensionId,
+          connectInfo
+        )
+      },
+      'extension.connect',
+      'runtime.connect',
+      'runtime.connect'
+    )
+  }
+  sendMessage(message, responseCallback) {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.sendMessage(message, responseCallback, undefined, undefined)
+      },
+      'extension.sendMessage',
+      'runtime.sendMessage',
+      'runtime.sendMessage'
+    )
+  }
+  sendRequest(extensionId, message, options, responseCallback) {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.sendMessage(extensionId, message, options, responseCallback)
+      },
+      'extension.sendRequest',
+      'runtime.sendMessage',
+      'runtime.sendMessage'
+    )
+  }
+  isAllowedFileSchemeAccess(callback) {
+    bridgeLog.LogUnavailbleApi('extension.isAllowedFileSchemeAccess')
+  }
+  isAllowedIncognitoAccess(callback) {
+    bridgeLog.LogUnavailbleApi('extension.isAllowedIncognitoAccess')
+  }
+  setUpdateUrlData(data) {
+    bridgeLog.LogUnavailbleApi('extension.setUpdateUrlData')
+  }
 }
 class EdgeHistoryBridge {
-    get onVisited() { bridgeLog.LogUnavailbleApi("history.onVisited"); return bridgeHelper.fakeEvent; }
-    get onVisitRemoved() { bridgeLog.LogUnavailbleApi("history.onVisitRemoved"); return bridgeHelper.fakeEvent; }
-    addUrl(details, callback) {
-        bridgeLog.LogUnavailbleApi("history.addUrl");
-    }
-    deleteAll(callback) {
-        bridgeLog.LogUnavailbleApi("history.deleteAll");
-    }
-    deleteRange(range, callback) {
-        bridgeLog.LogUnavailbleApi("history.deleteRange");
-    }
-    deleteUrl(details, callback) {
-        bridgeLog.LogUnavailbleApi("history.deleteUrl");
-    }
-    getVisits(details, callback) {
-        bridgeLog.LogUnavailbleApi("history.getVisits");
-    }
-    search(query, callback) {
-        bridgeLog.LogUnavailbleApi("history.search");
-    }
+  get onVisited() {
+    bridgeLog.LogUnavailbleApi('history.onVisited')
+    return bridgeHelper.fakeEvent
+  }
+  get onVisitRemoved() {
+    bridgeLog.LogUnavailbleApi('history.onVisitRemoved')
+    return bridgeHelper.fakeEvent
+  }
+  addUrl(details, callback) {
+    bridgeLog.LogUnavailbleApi('history.addUrl')
+  }
+  deleteAll(callback) {
+    bridgeLog.LogUnavailbleApi('history.deleteAll')
+  }
+  deleteRange(range, callback) {
+    bridgeLog.LogUnavailbleApi('history.deleteRange')
+  }
+  deleteUrl(details, callback) {
+    bridgeLog.LogUnavailbleApi('history.deleteUrl')
+  }
+  getVisits(details, callback) {
+    bridgeLog.LogUnavailbleApi('history.getVisits')
+  }
+  search(query, callback) {
+    bridgeLog.LogUnavailbleApi('history.search')
+  }
 }
 class EdgeI18nBridge {
-    getAcceptLanguages(callback) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.i18n.getAcceptLanguages(callback);
-        }, "i18n.getAcceptLanguages");
-    }
-    getMessage(messageName, substitutions) {
-        return bridgeLog.DoActionAndLog(() => {
-            if (messageName.indexOf("@@extension_id") > -1) {
-                return myBrowser.runtime.id;
-            }
-            if (typeof substitutions !== "undefined" && typeof substitutions !== "null") {
-                return myBrowser.i18n.getMessage(messageName, substitutions);
-            }
-            else {
-                return myBrowser.i18n.getMessage(messageName);
-            }
-        }, "i18n.getMessage");
-    }
-    getUILanguage() {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.i18n.getUILanguage();
-        }, "i18n.getUILanguage");
-    }
+  getAcceptLanguages(callback) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.i18n.getAcceptLanguages(callback)
+    }, 'i18n.getAcceptLanguages')
+  }
+  getMessage(messageName, substitutions) {
+    return bridgeLog.DoActionAndLog(() => {
+      if (messageName.indexOf('@@extension_id') > -1) {
+        return myBrowser.runtime.id
+      }
+      if (typeof substitutions !== 'undefined' && typeof substitutions !== 'null') {
+        return myBrowser.i18n.getMessage(messageName, substitutions)
+      } else {
+        return myBrowser.i18n.getMessage(messageName)
+      }
+    }, 'i18n.getMessage')
+  }
+  getUILanguage() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.i18n.getUILanguage()
+    }, 'i18n.getUILanguage')
+  }
 }
 class EdgeNotificationBridge {
-    get onButtonClicked() { bridgeLog.LogUnavailbleApi("notifications.onButtonClicked"); return bridgeHelper.fakeEvent; }
-    get onClicked() { bridgeLog.LogUnavailbleApi("notifications.onClicked"); return bridgeHelper.fakeEvent; }
-    get onClosed() { bridgeLog.LogUnavailbleApi("notifications.onClosed"); return bridgeHelper.fakeEvent; }
-    get onPermissionLevelChanged() { bridgeLog.LogUnavailbleApi("notifications.onPermissionLevelChanged"); return bridgeHelper.fakeEvent; }
-    get onShowSettings() { bridgeLog.LogUnavailbleApi("notifications.onShowSettings"); return bridgeHelper.fakeEvent; }
-    clear(notificationId, callback) {
-        bridgeLog.LogUnavailbleApi("notifications.clear");
-    }
-    create(notificationId, options, callback) {
-        bridgeLog.LogUnavailbleApi("notifications.create");
-    }
-    getAll(callback) {
-        bridgeLog.LogUnavailbleApi("notifications.getAll");
-    }
-    getPermissionLevel(callback) {
-        bridgeLog.LogUnavailbleApi("notifications.getPermissionLevel");
-    }
-    update(notificationId, options, callback) {
-        bridgeLog.LogUnavailbleApi("notifications.update");
-    }
+  get onButtonClicked() {
+    bridgeLog.LogUnavailbleApi('notifications.onButtonClicked')
+    return bridgeHelper.fakeEvent
+  }
+  get onClicked() {
+    bridgeLog.LogUnavailbleApi('notifications.onClicked')
+    return bridgeHelper.fakeEvent
+  }
+  get onClosed() {
+    bridgeLog.LogUnavailbleApi('notifications.onClosed')
+    return bridgeHelper.fakeEvent
+  }
+  get onPermissionLevelChanged() {
+    bridgeLog.LogUnavailbleApi('notifications.onPermissionLevelChanged')
+    return bridgeHelper.fakeEvent
+  }
+  get onShowSettings() {
+    bridgeLog.LogUnavailbleApi('notifications.onShowSettings')
+    return bridgeHelper.fakeEvent
+  }
+  clear(notificationId, callback) {
+    bridgeLog.LogUnavailbleApi('notifications.clear')
+  }
+  create(notificationId, options, callback) {
+    bridgeLog.LogUnavailbleApi('notifications.create')
+  }
+  getAll(callback) {
+    bridgeLog.LogUnavailbleApi('notifications.getAll')
+  }
+  getPermissionLevel(callback) {
+    bridgeLog.LogUnavailbleApi('notifications.getPermissionLevel')
+  }
+  update(notificationId, options, callback) {
+    bridgeLog.LogUnavailbleApi('notifications.update')
+  }
 }
 class EdgePageActionBridge {
-    get onClicked() { return bridgeLog.DoActionAndLog(() => { return myBrowser.pageAction.onClicked; }, "pageAction.onClicked"); }
-    getPopup(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.pageAction.getPopup(details, callback);
-        }, "pageAction.getPopup");
-    }
-    getTitle(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.pageAction.getTitle(details, callback);
-        }, "pageAction.getTitle");
-    }
-    hide(tabId) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.pageAction.hide(tabId);
-        }, "pageAction.hide");
-    }
-    setTitle(details) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.pageAction.setTitle(details);
-        }, "pageAction.setTitle");
-    }
-    setIcon(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.pageAction.setIcon(details, callback);
-            }
-            else {
-                myBrowser.pageAction.setIcon(details, callback);
-            }
-        }, "pageAction.setIcon");
-    }
-    setPopup(details) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.pageAction.setPopup(details);
-        }, "pageAction.setPopup");
-    }
-    show(tabId) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.pageAction.show(tabId);
-        }, "pageAction.show");
-    }
+  get onClicked() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.pageAction.onClicked
+    }, 'pageAction.onClicked')
+  }
+  getPopup(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.pageAction.getPopup(details, callback)
+    }, 'pageAction.getPopup')
+  }
+  getTitle(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.pageAction.getTitle(details, callback)
+    }, 'pageAction.getTitle')
+  }
+  hide(tabId) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.pageAction.hide(tabId)
+    }, 'pageAction.hide')
+  }
+  setTitle(details) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.pageAction.setTitle(details)
+    }, 'pageAction.setTitle')
+  }
+  setIcon(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.pageAction.setIcon(details, callback)
+      } else {
+        myBrowser.pageAction.setIcon(details, callback)
+      }
+    }, 'pageAction.setIcon')
+  }
+  setPopup(details) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.pageAction.setPopup(details)
+    }, 'pageAction.setPopup')
+  }
+  show(tabId) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.pageAction.show(tabId)
+    }, 'pageAction.show')
+  }
 }
 class EdgePermissionsBridge {
-    get onAdded() { bridgeLog.LogUnavailbleApi("permissions.onAdded"); return bridgeHelper.fakeEvent; }
-    get onRemoved() { bridgeLog.LogUnavailbleApi("permissions.onRemoved"); return bridgeHelper.fakeEvent; }
-    contains(permissions, callback) {
-        bridgeLog.LogUnavailbleApi("permissions.contains");
-    }
-    getAll(callback) {
-        bridgeLog.LogUnavailbleApi("permissions.getAll");
-    }
-    remove(permissions, callback) {
-        bridgeLog.LogUnavailbleApi("permissions.remove");
-    }
-    request(permissions, callback) {
-        bridgeLog.LogUnavailbleApi("permissions.request");
-    }
+  get onAdded() {
+    bridgeLog.LogUnavailbleApi('permissions.onAdded')
+    return bridgeHelper.fakeEvent
+  }
+  get onRemoved() {
+    bridgeLog.LogUnavailbleApi('permissions.onRemoved')
+    return bridgeHelper.fakeEvent
+  }
+  contains(permissions, callback) {
+    bridgeLog.LogUnavailbleApi('permissions.contains')
+  }
+  getAll(callback) {
+    bridgeLog.LogUnavailbleApi('permissions.getAll')
+  }
+  remove(permissions, callback) {
+    bridgeLog.LogUnavailbleApi('permissions.remove')
+  }
+  request(permissions, callback) {
+    bridgeLog.LogUnavailbleApi('permissions.request')
+  }
 }
 class EdgeRuntimeBridge {
-    get id() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.id; }, "runtime.id"); }
-    get lastError() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.lastError; }, "runtime.lastError"); }
-    get onConnect() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onConnect; }, "runtime.onConnect"); }
-    get onInstalled() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onInstalled; }, "runtime.onInstalled"); }
-    get onMessage() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessage; }, "runtime.onMessage"); }
-    get onMessageExternal() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessageExternal; }, "runtime.onMessageExternal"); }
-    connect(extensionId, connectInfo) {
-        return bridgeLog.DoActionAndLog(() => {
-            if (typeof connectInfo !== "undefined" && typeof connectInfo !== "null") {
-                return myBrowser.runtime.connect(extensionId, connectInfo);
-            }
-            else {
-                return myBrowser.runtime.connect(extensionId);
-            }
-        }, "runtime.connect");
-    }
-    getBackgroundPage(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.runtime.getBackgroundPage(callback);
-        }, "runtime.getBackgroundPage");
-    }
-    getManifest() {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.runtime.getManifest();
-        }, "runtime.getManifest");
-    }
-    getURL(path) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.runtime.getURL(path);
-        }, "runtime.getURL");
-    }
-    sendMessage(extensionId, message, options, responseCallback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof responseCallback !== "undefined" && typeof responseCallback !== "null") {
-                myBrowser.runtime.sendMessage(extensionId, message, options, responseCallback);
-            }
-            else if (typeof options !== "undefined" && typeof options !== "null") {
-                myBrowser.runtime.sendMessage(extensionId, message, options);
-            }
-            else if (typeof message !== "undefined" && typeof message !== "null") {
-                myBrowser.runtime.sendMessage(extensionId, message);
-            }
-            else {
-                myBrowser.runtime.sendMessage(undefined, extensionId);
-            }
-        }, "runtime.sendMessage");
-    }
+  get id() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.id
+    }, 'runtime.id')
+  }
+  get lastError() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.lastError
+    }, 'runtime.lastError')
+  }
+  get onConnect() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onConnect
+    }, 'runtime.onConnect')
+  }
+  get onInstalled() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onInstalled
+    }, 'runtime.onInstalled')
+  }
+  get onMessage() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onMessage
+    }, 'runtime.onMessage')
+  }
+  get onMessageExternal() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onMessageExternal
+    }, 'runtime.onMessageExternal')
+  }
+  connect(extensionId, connectInfo) {
+    return bridgeLog.DoActionAndLog(() => {
+      if (typeof connectInfo !== 'undefined' && typeof connectInfo !== 'null') {
+        return myBrowser.runtime.connect(
+          extensionId,
+          connectInfo
+        )
+      } else {
+        return myBrowser.runtime.connect(extensionId)
+      }
+    }, 'runtime.connect')
+  }
+  getBackgroundPage(callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.runtime.getBackgroundPage(callback)
+    }, 'runtime.getBackgroundPage')
+  }
+  getManifest() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.getManifest()
+    }, 'runtime.getManifest')
+  }
+  getURL(path) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.getURL(path)
+    }, 'runtime.getURL')
+  }
+  sendMessage(extensionId, message, options, responseCallback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof responseCallback !== 'undefined' && typeof responseCallback !== 'null') {
+        myBrowser.runtime.sendMessage(extensionId, message, options, responseCallback)
+      } else if (typeof options !== 'undefined' && typeof options !== 'null') {
+        myBrowser.runtime.sendMessage(extensionId, message, options)
+      } else if (typeof message !== 'undefined' && typeof message !== 'null') {
+        myBrowser.runtime.sendMessage(extensionId, message)
+      } else {
+        myBrowser.runtime.sendMessage(undefined, extensionId)
+      }
+    }, 'runtime.sendMessage')
+  }
 }
 class EdgeChromeRuntimeBridge extends EdgeRuntimeBridge {
-    get onConnectExternal() { bridgeLog.LogUnavailbleApi("runtime.onConnectExternal"); return bridgeHelper.fakeEvent; }
-    get onRestartRequired() { bridgeLog.LogUnavailbleApi("runtime.onRestartRequired"); return bridgeHelper.fakeEvent; }
-    get onStartup() { bridgeLog.LogUnavailbleApi("runtime.onStartup"); return bridgeHelper.fakeEvent; }
-    get onSuspend() { bridgeLog.LogUnavailbleApi("runtime.onSuspend"); return bridgeHelper.fakeEvent; }
-    get onSuspendCanceled() { bridgeLog.LogUnavailbleApi("runtime.onSuspendCanceled"); return bridgeHelper.fakeEvent; }
-    get onUpdateAvailable() { bridgeLog.LogUnavailbleApi("runtime.onUpdateAvailable"); return bridgeHelper.fakeEvent; }
-    openOptionsPage(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            var optionsPage = myBrowser.runtime.getManifest()["options_page"];
-            var optionsPageUrl = myBrowser.runtime.getURL(optionsPage);
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.create({ url: optionsPageUrl }, callback);
-            }
-            else {
-                myBrowser.tabs.create({ url: optionsPageUrl });
-            }
-        }, "runtime.openOptionsPage", undefined, "tabs.create({ url: optionsPageUrl })");
-    }
-    connectNative(application) {
-        bridgeLog.LogUnavailbleApi("runtime.connectNative");
-        return null;
-    }
-    getPackageDirectoryEntry(callback) {
-        bridgeLog.LogUnavailbleApi("runtime.getPackageDirectoryEntry");
-    }
-    getPlatformInfo(callback) {
-        bridgeLog.LogUnavailbleApi("runtime.getPlatformInfo");
-    }
-    reload() {
-        bridgeLog.LogUnavailbleApi("runtime.reload");
-    }
-    requestUpdateCheck(callback) {
-        bridgeLog.LogUnavailbleApi("runtime.requestUpdateCheck");
-    }
-    restart() {
-        bridgeLog.LogUnavailbleApi("runtime.restart");
-    }
-    setUninstallURL(url, callback) {
-        bridgeLog.LogUnavailbleApi("runtime.setUninstallURL");
-    }
-    sendNativeMessage(application, message, responseCallback) {
-        bridgeLog.LogUnavailbleApi("runtime.sendNativeMessage");
-    }
+  get onConnectExternal() {
+    bridgeLog.LogUnavailbleApi('runtime.onConnectExternal')
+    return bridgeHelper.fakeEvent
+  }
+  get onRestartRequired() {
+    bridgeLog.LogUnavailbleApi('runtime.onRestartRequired')
+    return bridgeHelper.fakeEvent
+  }
+  get onStartup() {
+    bridgeLog.LogUnavailbleApi('runtime.onStartup')
+    return bridgeHelper.fakeEvent
+  }
+  get onSuspend() {
+    bridgeLog.LogUnavailbleApi('runtime.onSuspend')
+    return bridgeHelper.fakeEvent
+  }
+  get onSuspendCanceled() {
+    bridgeLog.LogUnavailbleApi('runtime.onSuspendCanceled')
+    return bridgeHelper.fakeEvent
+  }
+  get onUpdateAvailable() {
+    bridgeLog.LogUnavailbleApi('runtime.onUpdateAvailable')
+    return bridgeHelper.fakeEvent
+  }
+  openOptionsPage(callback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        var optionsPage = myBrowser.runtime.getManifest()['options_page']
+        var optionsPageUrl = myBrowser.runtime.getURL(optionsPage)
+        if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+          myBrowser.tabs.create({ url: optionsPageUrl }, callback)
+        } else {
+          myBrowser.tabs.create({ url: optionsPageUrl })
+        }
+      },
+      'runtime.openOptionsPage',
+      undefined,
+      'tabs.create({ url: optionsPageUrl })'
+    )
+  }
+  connectNative(application) {
+    bridgeLog.LogUnavailbleApi('runtime.connectNative')
+    return null
+  }
+  getPackageDirectoryEntry(callback) {
+    bridgeLog.LogUnavailbleApi('runtime.getPackageDirectoryEntry')
+  }
+  getPlatformInfo(callback) {
+    bridgeLog.LogUnavailbleApi('runtime.getPlatformInfo')
+  }
+  reload() {
+    bridgeLog.LogUnavailbleApi('runtime.reload')
+  }
+  requestUpdateCheck(callback) {
+    bridgeLog.LogUnavailbleApi('runtime.requestUpdateCheck')
+  }
+  restart() {
+    bridgeLog.LogUnavailbleApi('runtime.restart')
+  }
+  setUninstallURL(url, callback) {
+    bridgeLog.LogUnavailbleApi('runtime.setUninstallURL')
+  }
+  sendNativeMessage(application, message, responseCallback) {
+    bridgeLog.LogUnavailbleApi('runtime.sendNativeMessage')
+  }
 }
 class EdgeStorageBridge {
-    get local() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.local; }, "storage.local"); }
-    get onChanged() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.onChanged; }, "storage.onChanged"); }
+  get local() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.storage.local
+    }, 'storage.local')
+  }
+  get onChanged() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.storage.onChanged
+    }, 'storage.onChanged')
+  }
 }
 class EdgeChromeStorageBridge extends EdgeStorageBridge {
-    get managed() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.local; }, "storage.managed", undefined, "storage.local"); }
-    get sync() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.local; }, "storage.sync", undefined, "storage.local"); }
+  get managed() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.storage.local
+      },
+      'storage.managed',
+      undefined,
+      'storage.local'
+    )
+  }
+  get sync() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.storage.local
+      },
+      'storage.sync',
+      undefined,
+      'storage.local'
+    )
+  }
 }
 class EdgeTabsBridge {
-    get onActivated() { return bridgeLog.DoActionAndLog(() => { return myBrowser.tabs.onActivated; }, "tabs.onActivated"); }
-    get onCreated() { return bridgeLog.DoActionAndLog(() => { return myBrowser.tabs.onCreated; }, "tabs.onCreated"); }
-    get onRemoved() { return bridgeLog.DoActionAndLog(() => { return myBrowser.tabs.onRemoved; }, "tabs.onRemoved"); }
-    get onReplaced() { return bridgeLog.DoActionAndLog(() => { return myBrowser.tabs.onReplaced; }, "tabs.onReplaced"); }
-    get onUpdated() { return bridgeLog.DoActionAndLog(() => { return myBrowser.tabs.onUpdated; }, "tabs.onUpdated"); }
-    create(createProperties, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.create(createProperties, callback);
-            }
-            else {
-                myBrowser.tabs.create(createProperties);
-            }
-        }, "tabs.create");
-    }
-    detectLanguage(tabId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.tabs.detectLanguage(tabId, callback);
-        }, "tabs.detectLanguage");
-    }
-    executeScript(tabId, details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.executeScript(tabId, details, callback);
-            }
-            else {
-                myBrowser.tabs.executeScript(tabId, details);
-            }
-        }, "tabs.executeScript");
-    }
-    get(tabId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.tabs.get(tabId, callback);
-        }, "tabs.get");
-    }
-    getCurrent(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.tabs.getCurrent(callback);
-        }, "tabs.getCurrent");
-    }
-    insertCSS(tabId, details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.insertCSS(tabId, details, callback);
-            }
-            else {
-                myBrowser.tabs.insertCSS(tabId, details);
-            }
-        }, "tabs.insertCSS");
-    }
-    query(queryInfo, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.tabs.query(queryInfo, callback);
-        }, "tabs.query");
-    }
-    remove(tabId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.remove(tabId, callback);
-            }
-            else {
-                myBrowser.tabs.remove(tabId);
-            }
-        }, "tabs.remove");
-    }
-    sendMessage(tabId, message, responseCallback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof responseCallback !== "undefined" && typeof responseCallback !== "null") {
-                myBrowser.tabs.sendMessage(tabId, message, responseCallback);
-            }
-            else {
-                myBrowser.tabs.sendMessage(tabId, message);
-            }
-        }, "tabs.sendMessage");
-    }
-    update(tabId, updateProperties, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.update(tabId, updateProperties, callback);
-            }
-            else {
-                myBrowser.tabs.update(tabId, updateProperties);
-            }
-        }, "tabs.update");
-    }
+  get onActivated() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.tabs.onActivated
+    }, 'tabs.onActivated')
+  }
+  get onCreated() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.tabs.onCreated
+    }, 'tabs.onCreated')
+  }
+  get onRemoved() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.tabs.onRemoved
+    }, 'tabs.onRemoved')
+  }
+  get onReplaced() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.tabs.onReplaced
+    }, 'tabs.onReplaced')
+  }
+  get onUpdated() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.tabs.onUpdated
+    }, 'tabs.onUpdated')
+  }
+  create(createProperties, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.tabs.create(createProperties, callback)
+      } else {
+        myBrowser.tabs.create(createProperties)
+      }
+    }, 'tabs.create')
+  }
+  detectLanguage(tabId, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.tabs.detectLanguage(tabId, callback)
+    }, 'tabs.detectLanguage')
+  }
+  executeScript(tabId, details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.tabs.executeScript(tabId, details, callback)
+      } else {
+        myBrowser.tabs.executeScript(tabId, details)
+      }
+    }, 'tabs.executeScript')
+  }
+  get(tabId, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.tabs.get(tabId, callback)
+    }, 'tabs.get')
+  }
+  getCurrent(callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.tabs.getCurrent(callback)
+    }, 'tabs.getCurrent')
+  }
+  insertCSS(tabId, details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.tabs.insertCSS(tabId, details, callback)
+      } else {
+        myBrowser.tabs.insertCSS(tabId, details)
+      }
+    }, 'tabs.insertCSS')
+  }
+  query(queryInfo, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.tabs.query(queryInfo, callback)
+    }, 'tabs.query')
+  }
+  remove(tabId, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.tabs.remove(tabId, callback)
+      } else {
+        myBrowser.tabs.remove(tabId)
+      }
+    }, 'tabs.remove')
+  }
+  sendMessage(tabId, message, responseCallback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof responseCallback !== 'undefined' && typeof responseCallback !== 'null') {
+        myBrowser.tabs.sendMessage(tabId, message, responseCallback)
+      } else {
+        myBrowser.tabs.sendMessage(tabId, message)
+      }
+    }, 'tabs.sendMessage')
+  }
+  update(tabId, updateProperties, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.tabs.update(tabId, updateProperties, callback)
+      } else {
+        myBrowser.tabs.update(tabId, updateProperties)
+      }
+    }, 'tabs.update')
+  }
 }
 class EdgeChromeTabsBridge extends EdgeTabsBridge {
-    get onAttached() { bridgeLog.LogUnavailbleApi("tabs.onAttached"); return bridgeHelper.fakeEvent; }
-    get onDetached() { bridgeLog.LogUnavailbleApi("tabs.onDetached"); return bridgeHelper.fakeEvent; }
-    get onHighlighted() { bridgeLog.LogUnavailbleApi("tabs.onHighlighted"); return bridgeHelper.fakeEvent; }
-    get onMoved() { bridgeLog.LogUnavailbleApi("tabs.onMoved"); return bridgeHelper.fakeEvent; }
-    get onSelectionChanged() {
-        return bridgeLog.DoActionAndLog(() => {
-            var fakeEvent = bridgeHelper.fakeEvent;
-            fakeEvent.addListener = (callback) => {
-                myBrowser.tabs.onActivated.addListener((activeInfo) => {
-                    callback(activeInfo.tabId, { windowId: activeInfo.windowId });
-                });
-            };
-            return fakeEvent;
-        }, "tabs.onSelectionChanged", "tabs.onActivated", "tabs.onActivated");
-    }
-    duplicate(tabId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            this.get(tabId, function (tab) {
-                if (typeof callback !== "undefined" && typeof callback !== "null") {
-                    myBrowser.tabs.create({ url: tab.url }, callback);
-                }
-                else {
-                    myBrowser.tabs.create({ url: tab.url });
-                }
-            });
-        }, "tabs.duplicate", undefined, "tabs.create");
-    }
-    getAllInWindow(windowId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            this.query({ windowId: windowId }, callback);
-        }, "tabs.getAllInWindow", "tabs.query", "tabs.query");
-    }
-    getSelected(windowId, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            this.query({ active: true }, (tabs) => callback(tabs[0]));
-        }, "tabs.getSelected", "tabs.query", "tabs.query");
-    }
-    sendRequest(tabId, request, responseCallback) {
-        bridgeLog.DoActionAndLog(() => {
-            this.sendMessage(tabId, request, responseCallback);
-        }, "tabs.sendRequest", "tabs.sendMessage", "tabs.sendMessage");
-    }
-    captureVisibleTab(windowId, options, callback) {
-        bridgeLog.LogUnavailbleApi("tabs.captureVisibleTab");
-    }
-    connect(tabId, connectInfo) {
-        bridgeLog.LogUnavailbleApi("tabs.connect");
-        return null;
-    }
-    highlight(highlightInfo, callback) {
-        bridgeLog.LogUnavailbleApi("tabs.highlight");
-    }
-    move(tabId, moveProperties, callback) {
-        bridgeLog.LogUnavailbleApi("tabs.move");
-    }
-    reload(tabId, reloadProperties, callback) {
-        bridgeLog.LogUnavailbleApi("tabs.reload");
-    }
+  get onAttached() {
+    bridgeLog.LogUnavailbleApi('tabs.onAttached')
+    return bridgeHelper.fakeEvent
+  }
+  get onDetached() {
+    bridgeLog.LogUnavailbleApi('tabs.onDetached')
+    return bridgeHelper.fakeEvent
+  }
+  get onHighlighted() {
+    bridgeLog.LogUnavailbleApi('tabs.onHighlighted')
+    return bridgeHelper.fakeEvent
+  }
+  get onMoved() {
+    bridgeLog.LogUnavailbleApi('tabs.onMoved')
+    return bridgeHelper.fakeEvent
+  }
+  get onSelectionChanged() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        var fakeEvent = bridgeHelper.fakeEvent
+        fakeEvent.addListener = (callback) => {
+          myBrowser.tabs.onActivated.addListener((activeInfo) => {
+            callback(activeInfo.tabId, { windowId: activeInfo.windowId })
+          })
+        }
+        return fakeEvent
+      },
+      'tabs.onSelectionChanged',
+      'tabs.onActivated',
+      'tabs.onActivated'
+    )
+  }
+  duplicate(tabId, callback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        this.get(tabId, function(tab) {
+          if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+            myBrowser.tabs.create({ url: tab.url }, callback)
+          } else {
+            myBrowser.tabs.create({ url: tab.url })
+          }
+        })
+      },
+      'tabs.duplicate',
+      undefined,
+      'tabs.create'
+    )
+  }
+  getAllInWindow(windowId, callback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        this.query({ windowId: windowId }, callback)
+      },
+      'tabs.getAllInWindow',
+      'tabs.query',
+      'tabs.query'
+    )
+  }
+  getSelected(windowId, callback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        this.query({ active: true }, (tabs) => callback(tabs[0]))
+      },
+      'tabs.getSelected',
+      'tabs.query',
+      'tabs.query'
+    )
+  }
+  sendRequest(tabId, request, responseCallback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        this.sendMessage(tabId, request, responseCallback)
+      },
+      'tabs.sendRequest',
+      'tabs.sendMessage',
+      'tabs.sendMessage'
+    )
+  }
+  captureVisibleTab(windowId, options, callback) {
+    bridgeLog.LogUnavailbleApi('tabs.captureVisibleTab')
+  }
+  connect(tabId, connectInfo) {
+    bridgeLog.LogUnavailbleApi('tabs.connect')
+    return null
+  }
+  highlight(highlightInfo, callback) {
+    bridgeLog.LogUnavailbleApi('tabs.highlight')
+  }
+  move(tabId, moveProperties, callback) {
+    bridgeLog.LogUnavailbleApi('tabs.move')
+  }
+  reload(tabId, reloadProperties, callback) {
+    bridgeLog.LogUnavailbleApi('tabs.reload')
+  }
 }
 class EdgeWebNavigationBridge {
-    get onBeforeNavigate() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onBeforeNavigate; }, "webNavigation.onBeforeNavigate"); }
-    get onCommitted() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onCommitted; }, "webNavigation.onCommitted"); }
-    get onCompleted() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onCompleted; }, "webNavigation.onCompleted"); }
-    get onCreatedNavigationTarget() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onCreatedNavigationTarget; }, "webNavigation.onCreatedNavigationTarget"); }
-    get onDOMContentLoaded() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onDOMContentLoaded; }, "webNavigation.onDOMContentLoaded"); }
-    get onErrorOccurred() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onErrorOccurred; }, "webNavigation.onErrorOccurred"); }
-    get onHistoryStateUpdated() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onHistoryStateUpdated; }, "webNavigation.onHistoryStateUpdated"); }
-    get onReferenceFragmentUpdated() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onReferenceFragmentUpdated; }, "webNavigation.onReferenceFragmentUpdated"); }
-    get onTabReplaced() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webNavigation.onTabReplaced; }, "webNavigation.onTabReplaced"); }
-    getAllFrames(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.webNavigation.getAllFrames(details, callback);
-        }, "webNavigation.getAllFrames");
-    }
-    getFrame(details, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.webNavigation.getFrame(details, callback);
-        }, "webNavigation.getFrame");
-    }
+  get onBeforeNavigate() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onBeforeNavigate
+    }, 'webNavigation.onBeforeNavigate')
+  }
+  get onCommitted() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onCommitted
+    }, 'webNavigation.onCommitted')
+  }
+  get onCompleted() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onCompleted
+    }, 'webNavigation.onCompleted')
+  }
+  get onCreatedNavigationTarget() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onCreatedNavigationTarget
+    }, 'webNavigation.onCreatedNavigationTarget')
+  }
+  get onDOMContentLoaded() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onDOMContentLoaded
+    }, 'webNavigation.onDOMContentLoaded')
+  }
+  get onErrorOccurred() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onErrorOccurred
+    }, 'webNavigation.onErrorOccurred')
+  }
+  get onHistoryStateUpdated() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onHistoryStateUpdated
+    }, 'webNavigation.onHistoryStateUpdated')
+  }
+  get onReferenceFragmentUpdated() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onReferenceFragmentUpdated
+    }, 'webNavigation.onReferenceFragmentUpdated')
+  }
+  get onTabReplaced() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webNavigation.onTabReplaced
+    }, 'webNavigation.onTabReplaced')
+  }
+  getAllFrames(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.webNavigation.getAllFrames(details, callback)
+    }, 'webNavigation.getAllFrames')
+  }
+  getFrame(details, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.webNavigation.getFrame(details, callback)
+    }, 'webNavigation.getFrame')
+  }
 }
 class EdgeWebRequestBridge {
-    get MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES; }, "webNavigation.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES"); }
-    get onAuthRequired() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onAuthRequired; }, "webNavigation.onAuthRequired"); }
-    get onBeforeRedirect() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onBeforeRedirect; }, "webNavigation.onBeforeRedirect"); }
-    get onBeforeRequest() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onBeforeRequest; }, "webNavigation.onBeforeRequest"); }
-    get onBeforeSendHeaders() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onBeforeSendHeaders; }, "webNavigation.onBeforeSendHeaders"); }
-    get onCompleted() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onCompleted; }, "webNavigation.onCompleted"); }
-    get onErrorOccurred() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onErrorOccurred; }, "webNavigation.onErrorOccurred"); }
-    get onHeadersReceived() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onHeadersReceived; }, "webNavigation.onHeadersReceived"); }
-    get onResponseStarted() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onResponseStarted; }, "webNavigation.onResponseStarted"); }
-    get onSendHeaders() { return bridgeLog.DoActionAndLog(() => { return myBrowser.webRequest.onSendHeaders; }, "webNavigation.onSendHeaders"); }
-    handlerBehaviorChanged(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.webRequest.handlerBehaviorChanged(callback);
-            }
-            else {
-                myBrowser.webRequest.handlerBehaviorChanged();
-            }
-        }, "webRequest.handlerBehaviorChanged");
-    }
+  get MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES
+    }, 'webNavigation.MAX_HANDLER_BEHAVIOR_CHANGED_CALLS_PER_10_MINUTES')
+  }
+  get onAuthRequired() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onAuthRequired
+    }, 'webNavigation.onAuthRequired')
+  }
+  get onBeforeRedirect() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onBeforeRedirect
+    }, 'webNavigation.onBeforeRedirect')
+  }
+  get onBeforeRequest() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onBeforeRequest
+    }, 'webNavigation.onBeforeRequest')
+  }
+  get onBeforeSendHeaders() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onBeforeSendHeaders
+    }, 'webNavigation.onBeforeSendHeaders')
+  }
+  get onCompleted() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onCompleted
+    }, 'webNavigation.onCompleted')
+  }
+  get onErrorOccurred() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onErrorOccurred
+    }, 'webNavigation.onErrorOccurred')
+  }
+  get onHeadersReceived() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onHeadersReceived
+    }, 'webNavigation.onHeadersReceived')
+  }
+  get onResponseStarted() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onResponseStarted
+    }, 'webNavigation.onResponseStarted')
+  }
+  get onSendHeaders() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.webRequest.onSendHeaders
+    }, 'webNavigation.onSendHeaders')
+  }
+  handlerBehaviorChanged(callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.webRequest.handlerBehaviorChanged(callback)
+      } else {
+        myBrowser.webRequest.handlerBehaviorChanged()
+      }
+    }, 'webRequest.handlerBehaviorChanged')
+  }
 }
 class EdgeWindowsBridge {
-    get WINDOW_ID_CURRENT() { return bridgeLog.DoActionAndLog(() => { return myBrowser.windows.WINDOW_ID_CURRENT; }, "windows.WINDOW_ID_CURRENT"); }
-    get WINDOW_ID_NONE() { return bridgeLog.DoActionAndLog(() => { return myBrowser.windows.WINDOW_ID_NONE; }, "windows.WINDOW_ID_NONE"); }
-    get onCreated() { return bridgeLog.DoActionAndLog(() => { return myBrowser.windows.onCreated; }, "windows.onCreated"); }
-    get onFocusChanged() { return bridgeLog.DoActionAndLog(() => { return myBrowser.windows.onFocusChanged; }, "windows.onFocusChanged"); }
-    get onRemoved() { return bridgeLog.DoActionAndLog(() => { return myBrowser.windows.onRemoved; }, "windows.onRemoved"); }
-    create(createData, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.windows.create(createData, callback);
-            }
-            else {
-                myBrowser.windows.create(createData);
-            }
-        }, "windows.create");
-    }
-    get(windowId, getInfo, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.windows.get(windowId, getInfo, callback);
-        }, "windows.get");
-    }
-    getAll(getInfo, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.windows.getAll(getInfo, callback);
-        }, "windows.getAll");
-    }
-    getCurrent(getInfo, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.windows.getCurrent(getInfo, callback);
-        }, "windows.getCurrent");
-    }
-    getLastFocused(getInfo, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.windows.getLastFocused(getInfo, callback);
-        }, "windows.getLastFocused");
-    }
-    update(windowId, updateInfo, callback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.windows.update(windowId, updateInfo, callback);
-            }
-            else {
-                myBrowser.windows.update(windowId, updateInfo);
-            }
-        }, "windows.update");
-    }
+  get WINDOW_ID_CURRENT() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.windows.WINDOW_ID_CURRENT
+    }, 'windows.WINDOW_ID_CURRENT')
+  }
+  get WINDOW_ID_NONE() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.windows.WINDOW_ID_NONE
+    }, 'windows.WINDOW_ID_NONE')
+  }
+  get onCreated() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.windows.onCreated
+    }, 'windows.onCreated')
+  }
+  get onFocusChanged() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.windows.onFocusChanged
+    }, 'windows.onFocusChanged')
+  }
+  get onRemoved() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.windows.onRemoved
+    }, 'windows.onRemoved')
+  }
+  create(createData, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.windows.create(createData, callback)
+      } else {
+        myBrowser.windows.create(createData)
+      }
+    }, 'windows.create')
+  }
+  get(windowId, getInfo, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.windows.get(windowId, getInfo, callback)
+    }, 'windows.get')
+  }
+  getAll(getInfo, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.windows.getAll(getInfo, callback)
+    }, 'windows.getAll')
+  }
+  getCurrent(getInfo, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.windows.getCurrent(getInfo, callback)
+    }, 'windows.getCurrent')
+  }
+  getLastFocused(getInfo, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.windows.getLastFocused(getInfo, callback)
+    }, 'windows.getLastFocused')
+  }
+  update(windowId, updateInfo, callback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+        myBrowser.windows.update(windowId, updateInfo, callback)
+      } else {
+        myBrowser.windows.update(windowId, updateInfo)
+      }
+    }, 'windows.update')
+  }
 }
 class EdgeChromeWindowsBridge extends EdgeWindowsBridge {
-    remove(windowId, callback) {
-        bridgeLog.LogUnavailbleApi("windows.remove");
-    }
+  remove(windowId, callback) {
+    bridgeLog.LogUnavailbleApi('windows.remove')
+  }
 }
 class EdgeBackgroundBridge {
-    constructor() {
-        this.app = new EdgeChromeAppBridge();
-        this.browserAction = typeof browser.browserAction !== "undefined" ? new EdgeChromeBrowserActionBridge() : undefined;
-        this.contextMenus = typeof browser.contextMenus !== "undefined" ? new EdgeContextMenusBridge() : undefined;
-        this.cookies = typeof browser.cookies !== "undefined" ? new EdgeChromeCookiesBridge() : undefined;
-        this.extension = typeof browser.extension !== "undefined" ? new EdgeChromeExtensionBridge() : undefined;
-        this.history = typeof browser.history !== "undefined" ? new EdgeHistoryBridge() : undefined;
-        this.i18n = typeof browser.i18n !== "undefined" ? new EdgeI18nBridge() : undefined;
-        this.notifications = typeof browser.notifications !== "undefined" ? new EdgeNotificationBridge() : undefined;
-        this.pageAction = typeof browser.pageAction !== "undefined" ? new EdgePageActionBridge() : undefined;
-        this.permissions = typeof browser.permissions !== "undefined" ? new EdgePermissionsBridge() : undefined;
-        this.runtime = typeof browser.runtime !== "undefined" ? new EdgeChromeRuntimeBridge() : undefined;
-        this.storage = typeof browser.storage !== "undefined" ? new EdgeChromeStorageBridge() : undefined;
-        this.tabs = typeof browser.tabs !== "undefined" ? new EdgeChromeTabsBridge() : undefined;
-        this.webNavigation = typeof browser.webNavigation !== "undefined" ? new EdgeWebNavigationBridge() : undefined;
-        this.webRequest = typeof browser.webRequest !== "undefined" ? new EdgeWebRequestBridge() : undefined;
-        this.windows = typeof browser.windows !== "undefined" ? new EdgeChromeWindowsBridge() : undefined;
-    }
+  constructor() {
+    this.app = new EdgeChromeAppBridge()
+    this.browserAction = typeof browser.browserAction !== 'undefined' ? new EdgeChromeBrowserActionBridge() : undefined
+    this.contextMenus = typeof browser.contextMenus !== 'undefined' ? new EdgeContextMenusBridge() : undefined
+    this.cookies = typeof browser.cookies !== 'undefined' ? new EdgeChromeCookiesBridge() : undefined
+    this.extension = typeof browser.extension !== 'undefined' ? new EdgeChromeExtensionBridge() : undefined
+    this.history = typeof browser.history !== 'undefined' ? new EdgeHistoryBridge() : undefined
+    this.i18n = typeof browser.i18n !== 'undefined' ? new EdgeI18nBridge() : undefined
+    this.notifications = typeof browser.notifications !== 'undefined' ? new EdgeNotificationBridge() : undefined
+    this.pageAction = typeof browser.pageAction !== 'undefined' ? new EdgePageActionBridge() : undefined
+    this.permissions = typeof browser.permissions !== 'undefined' ? new EdgePermissionsBridge() : undefined
+    this.runtime = typeof browser.runtime !== 'undefined' ? new EdgeChromeRuntimeBridge() : undefined
+    this.storage = typeof browser.storage !== 'undefined' ? new EdgeChromeStorageBridge() : undefined
+    this.tabs = typeof browser.tabs !== 'undefined' ? new EdgeChromeTabsBridge() : undefined
+    this.webNavigation = typeof browser.webNavigation !== 'undefined' ? new EdgeWebNavigationBridge() : undefined
+    this.webRequest = typeof browser.webRequest !== 'undefined' ? new EdgeWebRequestBridge() : undefined
+    this.windows = typeof browser.windows !== 'undefined' ? new EdgeChromeWindowsBridge() : undefined
+  }
 }
-var myBrowser = browser;
-var chrome = new EdgeBackgroundBridge();
+var myBrowser = browser
+var chrome = new EdgeBackgroundBridge()

--- a/contentScriptsAPIBridge.js
+++ b/contentScriptsAPIBridge.js
@@ -1,323 +1,456 @@
-if (!Range.prototype["intersectsNode"]) {
-    Range.prototype["intersectsNode"] = function (node) {
-        let range = document.createRange();
-        range.selectNode(node);
-        return 0 > this.compareBoundaryPoints(Range.END_TO_START, range)
-            && 0 < this.compareBoundaryPoints(Range.START_TO_END, range);
-    };
+if (!Range.prototype['intersectsNode']) {
+  Range.prototype['intersectsNode'] = function(node) {
+    let range = document.createRange()
+    range.selectNode(node)
+    return (
+      0 > this.compareBoundaryPoints(Range.END_TO_START, range) &&
+      0 < this.compareBoundaryPoints(Range.START_TO_END, range)
+    )
+  }
 }
-var getExtensionProtocol = function () {
-    if (typeof browser == "undefined") {
-        if (typeof chrome !== "undefined")
-            return "chrome-extension://";
-    }
-    else {
-        return "ms-browser-extension://";
-    }
-};
+var getExtensionProtocol = function() {
+  if (typeof browser == 'undefined') {
+    if (typeof chrome !== 'undefined') return 'chrome-extension://'
+  } else {
+    return 'ms-browser-extension://'
+  }
+}
 class FakeEvent {
-    addListener(callback) { }
-    addRules(rules, callback) { }
-    getRules(ruleIdentifiers, callback) { }
-    hasListener(callback) { return false; }
-    hasListeners() { return false; }
-    removeRules(ruleIdentifiers, callback) { }
-    removeListener(callback) { }
+  addListener(callback) {}
+  addRules(rules, callback) {}
+  getRules(ruleIdentifiers, callback) {}
+  hasListener(callback) {
+    return false
+  }
+  hasListeners() {
+    return false
+  }
+  removeRules(ruleIdentifiers, callback) {}
+  removeListener(callback) {}
 }
 class EdgeBridgeHelper {
-    constructor() {
-        this.fakeEvent = new FakeEvent();
+  constructor() {
+    this.fakeEvent = new FakeEvent()
+  }
+  toAbsolutePath(relativePath) {
+    if (relativePath.indexOf('ms-browser-extension://') == 0) {
+      return relativePath.replace(myBrowser.runtime.getURL(''), '')
+    } else if (relativePath.indexOf('/') != 0) {
+      var absolutePath = ''
+      var documentPath = document.location.pathname
+      absolutePath = documentPath.substring(0, documentPath.lastIndexOf('/') + 1)
+      absolutePath += relativePath
+      return absolutePath
     }
-    toAbsolutePath(relativePath) {
-        if (relativePath.indexOf("ms-browser-extension://") == 0) {
-            return relativePath.replace(myBrowser.runtime.getURL(""), "");
-        }
-        else if (relativePath.indexOf("/") != 0) {
-            var absolutePath = "";
-            var documentPath = document.location.pathname;
-            absolutePath = documentPath.substring(0, documentPath.lastIndexOf("/") + 1);
-            absolutePath += relativePath;
-            return absolutePath;
-        }
-        return relativePath;
-    }
+    return relativePath
+  }
 }
-var bridgeHelper = new EdgeBridgeHelper();
+var bridgeHelper = new EdgeBridgeHelper()
 class EdgeBridgeDebugLog {
-    constructor() {
-        this.CatchOnException = true;
-        this.VerboseLogging = true;
-        this.FailedCalls = {};
-        this.SuccededCalls = {};
-        this.DeprecatedCalls = {};
-        this.BridgedCalls = {};
-        this.UnavailableApis = {};
-        this.EdgeIssues = {};
+  constructor() {
+    this.CatchOnException = true
+    this.VerboseLogging = true
+    this.FailedCalls = {}
+    this.SuccededCalls = {}
+    this.DeprecatedCalls = {}
+    this.BridgedCalls = {}
+    this.UnavailableApis = {}
+    this.EdgeIssues = {}
+  }
+  log(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.log(message)
+      }
+    } catch (e) {}
+  }
+  info(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.info(message)
+      }
+    } catch (e) {}
+  }
+  warn(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.warn(message)
+      }
+    } catch (e) {}
+  }
+  error(message) {
+    try {
+      if (this.VerboseLogging) {
+        console.error(message)
+      }
+    } catch (e) {}
+  }
+  DoActionAndLog(action, name, deprecatedTo, bridgedTo) {
+    var result
+    try {
+      result = action()
+      this.AddToCalledDictionary(this.SuccededCalls, name)
+      if (typeof deprecatedTo !== 'undefined' && typeof deprecatedTo !== 'null') {
+        this.warn('API Call Deprecated - Name: ' + name + ', Please use ' + deprecatedTo + ' instead!')
+        this.AddToCalledDictionary(this.DeprecatedCalls, name)
+      }
+      if (typeof bridgedTo !== 'undefined' && typeof bridgedTo !== 'null') {
+        this.info("API Call '" + name + "' has been bridged to another Edge API: " + bridgedTo)
+        this.AddToCalledDictionary(this.BridgedCalls, name)
+      }
+      return result
+    } catch (ex) {
+      this.AddToCalledDictionary(this.FailedCalls, name)
+      if (this.CatchOnException) this.error('API Call Failed: ' + name + ' - ' + ex)
+      else throw ex
     }
-    log(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.log(message);
-            }
-        }
-        catch (e) {
-        }
+  }
+  LogEdgeIssue(name, message) {
+    this.warn(message)
+    this.AddToCalledDictionary(this.EdgeIssues, name)
+  }
+  LogUnavailbleApi(name, deprecatedTo) {
+    this.warn("API Call '" + name + "' is not supported in Edge")
+    this.AddToCalledDictionary(this.UnavailableApis, name)
+    if (typeof deprecatedTo !== 'undefined' && typeof deprecatedTo !== 'null') {
+      this.warn('API Call Deprecated - Name: ' + name + ', Please use ' + deprecatedTo + ' instead!')
+      this.AddToCalledDictionary(this.DeprecatedCalls, name)
     }
-    info(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.info(message);
-            }
-        }
-        catch (e) {
-        }
+  }
+  AddToCalledDictionary(dictionary, name) {
+    if (typeof dictionary[name] !== 'undefined') {
+      dictionary[name]++
+    } else {
+      dictionary[name] = 1
     }
-    warn(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.warn(message);
-            }
-        }
-        catch (e) {
-        }
-    }
-    error(message) {
-        try {
-            if (this.VerboseLogging) {
-                console.error(message);
-            }
-        }
-        catch (e) {
-        }
-    }
-    DoActionAndLog(action, name, deprecatedTo, bridgedTo) {
-        var result;
-        try {
-            result = action();
-            this.AddToCalledDictionary(this.SuccededCalls, name);
-            if (typeof deprecatedTo !== "undefined" && typeof deprecatedTo !== "null") {
-                this.warn("API Call Deprecated - Name: " + name + ", Please use " + deprecatedTo + " instead!");
-                this.AddToCalledDictionary(this.DeprecatedCalls, name);
-            }
-            if (typeof bridgedTo !== "undefined" && typeof bridgedTo !== "null") {
-                this.info("API Call '" + name + "' has been bridged to another Edge API: " + bridgedTo);
-                this.AddToCalledDictionary(this.BridgedCalls, name);
-            }
-            return result;
-        }
-        catch (ex) {
-            this.AddToCalledDictionary(this.FailedCalls, name);
-            if (this.CatchOnException)
-                this.error("API Call Failed: " + name + " - " + ex);
-            else
-                throw ex;
-        }
-    }
-    LogEdgeIssue(name, message) {
-        this.warn(message);
-        this.AddToCalledDictionary(this.EdgeIssues, name);
-    }
-    LogUnavailbleApi(name, deprecatedTo) {
-        this.warn("API Call '" + name + "' is not supported in Edge");
-        this.AddToCalledDictionary(this.UnavailableApis, name);
-        if (typeof deprecatedTo !== "undefined" && typeof deprecatedTo !== "null") {
-            this.warn("API Call Deprecated - Name: " + name + ", Please use " + deprecatedTo + " instead!");
-            this.AddToCalledDictionary(this.DeprecatedCalls, name);
-        }
-    }
-    AddToCalledDictionary(dictionary, name) {
-        if (typeof dictionary[name] !== "undefined") {
-            dictionary[name]++;
-        }
-        else {
-            dictionary[name] = 1;
-        }
-    }
+  }
 }
-var bridgeLog = new EdgeBridgeDebugLog();
+var bridgeLog = new EdgeBridgeDebugLog()
 class EdgeExtensionBridge {
-    getBackgroundPage() {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.extension.getBackgroundPage();
-        }, "extension.getBackgroundPage");
-    }
-    getURL(path) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.extension.getURL(path);
-        }, "extension.getURL");
-    }
-    getViews(fetchProperties) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.extension.getViews(fetchProperties);
-        }, "extension.getViews");
-    }
+  getBackgroundPage() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.extension.getBackgroundPage()
+    }, 'extension.getBackgroundPage')
+  }
+  getURL(path) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.extension.getURL(path)
+    }, 'extension.getURL')
+  }
+  getViews(fetchProperties) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.extension.getViews(fetchProperties)
+    }, 'extension.getViews')
+  }
 }
 class EdgeChromeExtensionBridge extends EdgeExtensionBridge {
-    get onConnect() { return bridgeLog.DoActionAndLog(() => { return EdgeRuntimeBridge.prototype.onConnect; }, "extension.onConnect", "runtime.onConnect", "runtime.onConnect"); }
-    get onMessage() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessage; }, "extension.onMessage", "runtime.onMessage", "runtime.onMessage"); }
-    get onRequest() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessage; }, "extension.onRequest", "runtime.onMessage", "runtime.onMessage"); }
-    get onRequestExternal() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessageExternal; }, "extension.onRequestExternal", "runtime.onMessageExternal", "runtime.onMessageExternal"); }
-    get inIncognitoContext() { return bridgeLog.DoActionAndLog(() => { return myBrowser.extension["inPrivateContext"]; }, "extension.inIncognitoContext", undefined, "extension.inPrivateContext"); }
-    get lastError() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.lastError; }, "extension.lastError", undefined, "runtime.lastError"); }
-    connect(extensionId, connectInfo) {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeRuntimeBridge.prototype.connect(extensionId, connectInfo);
-        }, "extension.connect", "runtime.connect", "runtime.connect");
-    }
-    sendMessage(message, responseCallback) {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeRuntimeBridge.prototype.sendMessage(message, responseCallback, undefined, undefined);
-        }, "extension.sendMessage", "runtime.sendMessage", "runtime.sendMessage");
-    }
-    sendRequest(extensionId, message, options, responseCallback) {
-        return bridgeLog.DoActionAndLog(() => {
-            return EdgeRuntimeBridge.prototype.sendMessage(extensionId, message, options, responseCallback);
-        }, "extension.sendRequest", "runtime.sendMessage", "runtime.sendMessage");
-    }
-    isAllowedFileSchemeAccess(callback) {
-        bridgeLog.LogUnavailbleApi("extension.isAllowedFileSchemeAccess");
-    }
-    isAllowedIncognitoAccess(callback) {
-        bridgeLog.LogUnavailbleApi("extension.isAllowedIncognitoAccess");
-    }
-    setUpdateUrlData(data) {
-        bridgeLog.LogUnavailbleApi("extension.setUpdateUrlData");
-    }
+  get onConnect() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.onConnect
+      },
+      'extension.onConnect',
+      'runtime.onConnect',
+      'runtime.onConnect'
+    )
+  }
+  get onMessage() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.onMessage
+      },
+      'extension.onMessage',
+      'runtime.onMessage',
+      'runtime.onMessage'
+    )
+  }
+  get onRequest() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.onMessage
+      },
+      'extension.onRequest',
+      'runtime.onMessage',
+      'runtime.onMessage'
+    )
+  }
+  get onRequestExternal() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.onMessageExternal
+      },
+      'extension.onRequestExternal',
+      'runtime.onMessageExternal',
+      'runtime.onMessageExternal'
+    )
+  }
+  get inIncognitoContext() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.extension['inPrivateContext']
+      },
+      'extension.inIncognitoContext',
+      undefined,
+      'extension.inPrivateContext'
+    )
+  }
+  get lastError() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.runtime.lastError
+      },
+      'extension.lastError',
+      undefined,
+      'runtime.lastError'
+    )
+  }
+  connect(extensionId, connectInfo) {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.connect(
+          extensionId,
+          connectInfo
+        )
+      },
+      'extension.connect',
+      'runtime.connect',
+      'runtime.connect'
+    )
+  }
+  sendMessage(message, responseCallback) {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.sendMessage(message, responseCallback, undefined, undefined)
+      },
+      'extension.sendMessage',
+      'runtime.sendMessage',
+      'runtime.sendMessage'
+    )
+  }
+  sendRequest(extensionId, message, options, responseCallback) {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return EdgeRuntimeBridge.prototype.sendMessage(extensionId, message, options, responseCallback)
+      },
+      'extension.sendRequest',
+      'runtime.sendMessage',
+      'runtime.sendMessage'
+    )
+  }
+  isAllowedFileSchemeAccess(callback) {
+    bridgeLog.LogUnavailbleApi('extension.isAllowedFileSchemeAccess')
+  }
+  isAllowedIncognitoAccess(callback) {
+    bridgeLog.LogUnavailbleApi('extension.isAllowedIncognitoAccess')
+  }
+  setUpdateUrlData(data) {
+    bridgeLog.LogUnavailbleApi('extension.setUpdateUrlData')
+  }
 }
 class EdgeI18nBridge {
-    getAcceptLanguages(callback) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.i18n.getAcceptLanguages(callback);
-        }, "i18n.getAcceptLanguages");
-    }
-    getMessage(messageName, substitutions) {
-        return bridgeLog.DoActionAndLog(() => {
-            if (messageName.indexOf("@@extension_id") > -1) {
-                return myBrowser.runtime.id;
-            }
-            if (typeof substitutions !== "undefined" && typeof substitutions !== "null") {
-                return myBrowser.i18n.getMessage(messageName, substitutions);
-            }
-            else {
-                return myBrowser.i18n.getMessage(messageName);
-            }
-        }, "i18n.getMessage");
-    }
-    getUILanguage() {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.i18n.getUILanguage();
-        }, "i18n.getUILanguage");
-    }
+  getAcceptLanguages(callback) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.i18n.getAcceptLanguages(callback)
+    }, 'i18n.getAcceptLanguages')
+  }
+  getMessage(messageName, substitutions) {
+    return bridgeLog.DoActionAndLog(() => {
+      if (messageName.indexOf('@@extension_id') > -1) {
+        return myBrowser.runtime.id
+      }
+      if (typeof substitutions !== 'undefined' && typeof substitutions !== 'null') {
+        return myBrowser.i18n.getMessage(messageName, substitutions)
+      } else {
+        return myBrowser.i18n.getMessage(messageName)
+      }
+    }, 'i18n.getMessage')
+  }
+  getUILanguage() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.i18n.getUILanguage()
+    }, 'i18n.getUILanguage')
+  }
 }
 class EdgeRuntimeBridge {
-    get id() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.id; }, "runtime.id"); }
-    get lastError() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.lastError; }, "runtime.lastError"); }
-    get onConnect() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onConnect; }, "runtime.onConnect"); }
-    get onInstalled() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onInstalled; }, "runtime.onInstalled"); }
-    get onMessage() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessage; }, "runtime.onMessage"); }
-    get onMessageExternal() { return bridgeLog.DoActionAndLog(() => { return myBrowser.runtime.onMessageExternal; }, "runtime.onMessageExternal"); }
-    connect(extensionId, connectInfo) {
-        return bridgeLog.DoActionAndLog(() => {
-            if (typeof connectInfo !== "undefined" && typeof connectInfo !== "null") {
-                return myBrowser.runtime.connect(extensionId, connectInfo);
-            }
-            else {
-                return myBrowser.runtime.connect(extensionId);
-            }
-        }, "runtime.connect");
-    }
-    getBackgroundPage(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            myBrowser.runtime.getBackgroundPage(callback);
-        }, "runtime.getBackgroundPage");
-    }
-    getManifest() {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.runtime.getManifest();
-        }, "runtime.getManifest");
-    }
-    getURL(path) {
-        return bridgeLog.DoActionAndLog(() => {
-            return myBrowser.runtime.getURL(path);
-        }, "runtime.getURL");
-    }
-    sendMessage(extensionId, message, options, responseCallback) {
-        bridgeLog.DoActionAndLog(() => {
-            if (typeof responseCallback !== "undefined" && typeof responseCallback !== "null") {
-                myBrowser.runtime.sendMessage(extensionId, message, options, responseCallback);
-            }
-            else if (typeof options !== "undefined" && typeof options !== "null") {
-                myBrowser.runtime.sendMessage(extensionId, message, options);
-            }
-            else if (typeof message !== "undefined" && typeof message !== "null") {
-                myBrowser.runtime.sendMessage(extensionId, message);
-            }
-            else {
-                myBrowser.runtime.sendMessage(undefined, extensionId);
-            }
-        }, "runtime.sendMessage");
-    }
+  get id() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.id
+    }, 'runtime.id')
+  }
+  get lastError() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.lastError
+    }, 'runtime.lastError')
+  }
+  get onConnect() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onConnect
+    }, 'runtime.onConnect')
+  }
+  get onInstalled() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onInstalled
+    }, 'runtime.onInstalled')
+  }
+  get onMessage() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onMessage
+    }, 'runtime.onMessage')
+  }
+  get onMessageExternal() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.onMessageExternal
+    }, 'runtime.onMessageExternal')
+  }
+  connect(extensionId, connectInfo) {
+    return bridgeLog.DoActionAndLog(() => {
+      if (typeof connectInfo !== 'undefined' && typeof connectInfo !== 'null') {
+        return myBrowser.runtime.connect(
+          extensionId,
+          connectInfo
+        )
+      } else {
+        return myBrowser.runtime.connect(extensionId)
+      }
+    }, 'runtime.connect')
+  }
+  getBackgroundPage(callback) {
+    bridgeLog.DoActionAndLog(() => {
+      myBrowser.runtime.getBackgroundPage(callback)
+    }, 'runtime.getBackgroundPage')
+  }
+  getManifest() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.getManifest()
+    }, 'runtime.getManifest')
+  }
+  getURL(path) {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.runtime.getURL(path)
+    }, 'runtime.getURL')
+  }
+  sendMessage(extensionId, message, options, responseCallback) {
+    bridgeLog.DoActionAndLog(() => {
+      if (typeof responseCallback !== 'undefined' && typeof responseCallback !== 'null') {
+        myBrowser.runtime.sendMessage(extensionId, message, options, responseCallback)
+      } else if (typeof options !== 'undefined' && typeof options !== 'null') {
+        myBrowser.runtime.sendMessage(extensionId, message, options)
+      } else if (typeof message !== 'undefined' && typeof message !== 'null') {
+        myBrowser.runtime.sendMessage(extensionId, message)
+      } else {
+        myBrowser.runtime.sendMessage(undefined, extensionId)
+      }
+    }, 'runtime.sendMessage')
+  }
 }
 class EdgeChromeRuntimeBridge extends EdgeRuntimeBridge {
-    get onConnectExternal() { bridgeLog.LogUnavailbleApi("runtime.onConnectExternal"); return bridgeHelper.fakeEvent; }
-    get onRestartRequired() { bridgeLog.LogUnavailbleApi("runtime.onRestartRequired"); return bridgeHelper.fakeEvent; }
-    get onStartup() { bridgeLog.LogUnavailbleApi("runtime.onStartup"); return bridgeHelper.fakeEvent; }
-    get onSuspend() { bridgeLog.LogUnavailbleApi("runtime.onSuspend"); return bridgeHelper.fakeEvent; }
-    get onSuspendCanceled() { bridgeLog.LogUnavailbleApi("runtime.onSuspendCanceled"); return bridgeHelper.fakeEvent; }
-    get onUpdateAvailable() { bridgeLog.LogUnavailbleApi("runtime.onUpdateAvailable"); return bridgeHelper.fakeEvent; }
-    openOptionsPage(callback) {
-        bridgeLog.DoActionAndLog(() => {
-            var optionsPage = myBrowser.runtime.getManifest()["options_page"];
-            var optionsPageUrl = myBrowser.runtime.getURL(optionsPage);
-            if (typeof callback !== "undefined" && typeof callback !== "null") {
-                myBrowser.tabs.create({ url: optionsPageUrl }, callback);
-            }
-            else {
-                myBrowser.tabs.create({ url: optionsPageUrl });
-            }
-        }, "runtime.openOptionsPage", undefined, "tabs.create({ url: optionsPageUrl })");
-    }
-    connectNative(application) {
-        bridgeLog.LogUnavailbleApi("runtime.connectNative");
-        return null;
-    }
-    getPackageDirectoryEntry(callback) {
-        bridgeLog.LogUnavailbleApi("runtime.getPackageDirectoryEntry");
-    }
-    getPlatformInfo(callback) {
-        bridgeLog.LogUnavailbleApi("runtime.getPlatformInfo");
-    }
-    reload() {
-        bridgeLog.LogUnavailbleApi("runtime.reload");
-    }
-    requestUpdateCheck(callback) {
-        bridgeLog.LogUnavailbleApi("runtime.requestUpdateCheck");
-    }
-    restart() {
-        bridgeLog.LogUnavailbleApi("runtime.restart");
-    }
-    setUninstallURL(url, callback) {
-        bridgeLog.LogUnavailbleApi("runtime.setUninstallURL");
-    }
-    sendNativeMessage(application, message, responseCallback) {
-        bridgeLog.LogUnavailbleApi("runtime.sendNativeMessage");
-    }
+  get onConnectExternal() {
+    bridgeLog.LogUnavailbleApi('runtime.onConnectExternal')
+    return bridgeHelper.fakeEvent
+  }
+  get onRestartRequired() {
+    bridgeLog.LogUnavailbleApi('runtime.onRestartRequired')
+    return bridgeHelper.fakeEvent
+  }
+  get onStartup() {
+    bridgeLog.LogUnavailbleApi('runtime.onStartup')
+    return bridgeHelper.fakeEvent
+  }
+  get onSuspend() {
+    bridgeLog.LogUnavailbleApi('runtime.onSuspend')
+    return bridgeHelper.fakeEvent
+  }
+  get onSuspendCanceled() {
+    bridgeLog.LogUnavailbleApi('runtime.onSuspendCanceled')
+    return bridgeHelper.fakeEvent
+  }
+  get onUpdateAvailable() {
+    bridgeLog.LogUnavailbleApi('runtime.onUpdateAvailable')
+    return bridgeHelper.fakeEvent
+  }
+  openOptionsPage(callback) {
+    bridgeLog.DoActionAndLog(
+      () => {
+        var optionsPage = myBrowser.runtime.getManifest()['options_page']
+        var optionsPageUrl = myBrowser.runtime.getURL(optionsPage)
+        if (typeof callback !== 'undefined' && typeof callback !== 'null') {
+          myBrowser.tabs.create({ url: optionsPageUrl }, callback)
+        } else {
+          myBrowser.tabs.create({ url: optionsPageUrl })
+        }
+      },
+      'runtime.openOptionsPage',
+      undefined,
+      'tabs.create({ url: optionsPageUrl })'
+    )
+  }
+  connectNative(application) {
+    bridgeLog.LogUnavailbleApi('runtime.connectNative')
+    return null
+  }
+  getPackageDirectoryEntry(callback) {
+    bridgeLog.LogUnavailbleApi('runtime.getPackageDirectoryEntry')
+  }
+  getPlatformInfo(callback) {
+    bridgeLog.LogUnavailbleApi('runtime.getPlatformInfo')
+  }
+  reload() {
+    bridgeLog.LogUnavailbleApi('runtime.reload')
+  }
+  requestUpdateCheck(callback) {
+    bridgeLog.LogUnavailbleApi('runtime.requestUpdateCheck')
+  }
+  restart() {
+    bridgeLog.LogUnavailbleApi('runtime.restart')
+  }
+  setUninstallURL(url, callback) {
+    bridgeLog.LogUnavailbleApi('runtime.setUninstallURL')
+  }
+  sendNativeMessage(application, message, responseCallback) {
+    bridgeLog.LogUnavailbleApi('runtime.sendNativeMessage')
+  }
 }
 class EdgeStorageBridge {
-    get local() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.local; }, "storage.local"); }
-    get onChanged() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.onChanged; }, "storage.onChanged"); }
+  get local() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.storage.local
+    }, 'storage.local')
+  }
+  get onChanged() {
+    return bridgeLog.DoActionAndLog(() => {
+      return myBrowser.storage.onChanged
+    }, 'storage.onChanged')
+  }
 }
 class EdgeChromeStorageBridge extends EdgeStorageBridge {
-    get managed() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.local; }, "storage.managed", undefined, "storage.local"); }
-    get sync() { return bridgeLog.DoActionAndLog(() => { return myBrowser.storage.local; }, "storage.sync", undefined, "storage.local"); }
+  get managed() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.storage.local
+      },
+      'storage.managed',
+      undefined,
+      'storage.local'
+    )
+  }
+  get sync() {
+    return bridgeLog.DoActionAndLog(
+      () => {
+        return myBrowser.storage.local
+      },
+      'storage.sync',
+      undefined,
+      'storage.local'
+    )
+  }
 }
 class EdgeContentBridge {
-    constructor() {
-        this.extension = typeof browser.extension !== "undefined" ? new EdgeChromeExtensionBridge() : undefined;
-        this.i18n = typeof browser.i18n !== "undefined" ? new EdgeI18nBridge() : undefined;
-        this.runtime = typeof browser.runtime !== "undefined" ? new EdgeChromeRuntimeBridge() : undefined;
-        this.storage = typeof browser.storage !== "undefined" ? new EdgeChromeStorageBridge() : undefined;
-    }
+  constructor() {
+    this.extension = typeof browser.extension !== 'undefined' ? new EdgeChromeExtensionBridge() : undefined
+    this.i18n = typeof browser.i18n !== 'undefined' ? new EdgeI18nBridge() : undefined
+    this.runtime = typeof browser.runtime !== 'undefined' ? new EdgeChromeRuntimeBridge() : undefined
+    this.storage = typeof browser.storage !== 'undefined' ? new EdgeChromeStorageBridge() : undefined
+  }
 }
-var myBrowser = browser;
-var chrome = new EdgeContentBridge();
+var myBrowser = browser
+var chrome = new EdgeContentBridge()

--- a/handlebars.runtime-v4.0.10.js
+++ b/handlebars.runtime-v4.0.10.js
@@ -24,1445 +24,1504 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-(function webpackUniversalModuleDefinition(root, factory) {
-	if(typeof exports === 'object' && typeof module === 'object')
-		module.exports = factory();
-	else if(typeof define === 'function' && define.amd)
-		define([], factory);
-	else if(typeof exports === 'object')
-		exports["Handlebars"] = factory();
-	else
-		root["Handlebars"] = factory();
+;(function webpackUniversalModuleDefinition(root, factory) {
+  if (typeof exports === 'object' && typeof module === 'object') module.exports = factory()
+  else if (typeof define === 'function' && define.amd) define([], factory)
+  else if (typeof exports === 'object') exports['Handlebars'] = factory()
+  else root['Handlebars'] = factory()
 })(this, function() {
-return /******/ (function(modules) { // webpackBootstrap
-/******/ 	// The module cache
-/******/ 	var installedModules = {};
+  return /******/ (function(modules) {
+    // webpackBootstrap
+    /******/ // The module cache
+    /******/ var installedModules = {} // The require function
 
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
+    /******/ /******/ function __webpack_require__(moduleId) {
+      /******/ // Check if module is in cache
+      /******/ if (installedModules[moduleId]) /******/ return installedModules[moduleId].exports // Create a new module (and put it into the cache)
 
-/******/ 		// Check if module is in cache
-/******/ 		if(installedModules[moduleId])
-/******/ 			return installedModules[moduleId].exports;
+      /******/ /******/ var module = (installedModules[moduleId] = {
+        /******/ exports: {},
+        /******/ id: moduleId,
+        /******/ loaded: false
+        /******/
+      }) // Execute the module function
 
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = installedModules[moduleId] = {
-/******/ 			exports: {},
-/******/ 			id: moduleId,
-/******/ 			loaded: false
-/******/ 		};
+      /******/ /******/ modules[moduleId].call(module.exports, module, module.exports, __webpack_require__) // Flag the module as loaded
 
-/******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+      /******/ /******/ module.loaded = true // Return the exports of the module
 
-/******/ 		// Flag the module as loaded
-/******/ 		module.loaded = true;
+      /******/ /******/ return module.exports
+      /******/
+    } // expose the modules object (__webpack_modules__)
 
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
+    /******/ /******/ __webpack_require__.m = modules // expose the module cache
 
+    /******/ /******/ __webpack_require__.c = installedModules // __webpack_public_path__
 
-/******/ 	// expose the modules object (__webpack_modules__)
-/******/ 	__webpack_require__.m = modules;
+    /******/ /******/ __webpack_require__.p = '' // Load entry module and return exports
 
-/******/ 	// expose the module cache
-/******/ 	__webpack_require__.c = installedModules;
+    /******/ /******/ return __webpack_require__(0)
+    /******/
+  })(
+    /************************************************************************/
+    /******/ [
+      /* 0 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
 
-/******/ 	// __webpack_public_path__
-/******/ 	__webpack_require__.p = "";
+        var _interopRequireWildcard = __webpack_require__(1)['default']
 
-/******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(0);
-/******/ })
-/************************************************************************/
-/******/ ([
-/* 0 */
-/***/ (function(module, exports, __webpack_require__) {
+        var _interopRequireDefault = __webpack_require__(2)['default']
 
-	'use strict';
+        exports.__esModule = true
 
-	var _interopRequireWildcard = __webpack_require__(1)['default'];
+        var _handlebarsBase = __webpack_require__(3)
 
-	var _interopRequireDefault = __webpack_require__(2)['default'];
+        var base = _interopRequireWildcard(_handlebarsBase)
 
-	exports.__esModule = true;
+        // Each of these augment the Handlebars object. No need to setup here.
+        // (This is done to easily share code between commonjs and browse envs)
 
-	var _handlebarsBase = __webpack_require__(3);
+        var _handlebarsSafeString = __webpack_require__(20)
 
-	var base = _interopRequireWildcard(_handlebarsBase);
+        var _handlebarsSafeString2 = _interopRequireDefault(_handlebarsSafeString)
 
-	// Each of these augment the Handlebars object. No need to setup here.
-	// (This is done to easily share code between commonjs and browse envs)
+        var _handlebarsException = __webpack_require__(5)
 
-	var _handlebarsSafeString = __webpack_require__(20);
+        var _handlebarsException2 = _interopRequireDefault(_handlebarsException)
 
-	var _handlebarsSafeString2 = _interopRequireDefault(_handlebarsSafeString);
+        var _handlebarsUtils = __webpack_require__(4)
 
-	var _handlebarsException = __webpack_require__(5);
+        var Utils = _interopRequireWildcard(_handlebarsUtils)
 
-	var _handlebarsException2 = _interopRequireDefault(_handlebarsException);
+        var _handlebarsRuntime = __webpack_require__(21)
 
-	var _handlebarsUtils = __webpack_require__(4);
+        var runtime = _interopRequireWildcard(_handlebarsRuntime)
 
-	var Utils = _interopRequireWildcard(_handlebarsUtils);
+        var _handlebarsNoConflict = __webpack_require__(33)
 
-	var _handlebarsRuntime = __webpack_require__(21);
+        var _handlebarsNoConflict2 = _interopRequireDefault(_handlebarsNoConflict)
 
-	var runtime = _interopRequireWildcard(_handlebarsRuntime);
+        // For compatibility and usage outside of module systems, make the Handlebars object a namespace
+        function create() {
+          var hb = new base.HandlebarsEnvironment()
 
-	var _handlebarsNoConflict = __webpack_require__(33);
+          Utils.extend(hb, base)
+          hb.SafeString = _handlebarsSafeString2['default']
+          hb.Exception = _handlebarsException2['default']
+          hb.Utils = Utils
+          hb.escapeExpression = Utils.escapeExpression
 
-	var _handlebarsNoConflict2 = _interopRequireDefault(_handlebarsNoConflict);
+          hb.VM = runtime
+          hb.template = function(spec) {
+            return runtime.template(spec, hb)
+          }
 
-	// For compatibility and usage outside of module systems, make the Handlebars object a namespace
-	function create() {
-	  var hb = new base.HandlebarsEnvironment();
+          return hb
+        }
 
-	  Utils.extend(hb, base);
-	  hb.SafeString = _handlebarsSafeString2['default'];
-	  hb.Exception = _handlebarsException2['default'];
-	  hb.Utils = Utils;
-	  hb.escapeExpression = Utils.escapeExpression;
+        var inst = create()
+        inst.create = create
 
-	  hb.VM = runtime;
-	  hb.template = function (spec) {
-	    return runtime.template(spec, hb);
-	  };
+        _handlebarsNoConflict2['default'](inst)
 
-	  return hb;
-	}
+        inst['default'] = inst
 
-	var inst = create();
-	inst.create = create;
+        exports['default'] = inst
+        module.exports = exports['default']
 
-	_handlebarsNoConflict2['default'](inst);
-
-	inst['default'] = inst;
-
-	exports['default'] = inst;
-	module.exports = exports['default'];
-
-/***/ }),
-/* 1 */
-/***/ (function(module, exports) {
-
-	"use strict";
-
-	exports["default"] = function (obj) {
-	  if (obj && obj.__esModule) {
-	    return obj;
-	  } else {
-	    var newObj = {};
-
-	    if (obj != null) {
-	      for (var key in obj) {
-	        if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key];
-	      }
-	    }
-
-	    newObj["default"] = obj;
-	    return newObj;
-	  }
-	};
-
-	exports.__esModule = true;
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports) {
-
-	"use strict";
-
-	exports["default"] = function (obj) {
-	  return obj && obj.__esModule ? obj : {
-	    "default": obj
-	  };
-	};
-
-	exports.__esModule = true;
-
-/***/ }),
-/* 3 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _interopRequireDefault = __webpack_require__(2)['default'];
-
-	exports.__esModule = true;
-	exports.HandlebarsEnvironment = HandlebarsEnvironment;
-
-	var _utils = __webpack_require__(4);
-
-	var _exception = __webpack_require__(5);
-
-	var _exception2 = _interopRequireDefault(_exception);
-
-	var _helpers = __webpack_require__(9);
-
-	var _decorators = __webpack_require__(17);
-
-	var _logger = __webpack_require__(19);
-
-	var _logger2 = _interopRequireDefault(_logger);
-
-	var VERSION = '4.0.10';
-	exports.VERSION = VERSION;
-	var COMPILER_REVISION = 7;
-
-	exports.COMPILER_REVISION = COMPILER_REVISION;
-	var REVISION_CHANGES = {
-	  1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
-	  2: '== 1.0.0-rc.3',
-	  3: '== 1.0.0-rc.4',
-	  4: '== 1.x.x',
-	  5: '== 2.0.0-alpha.x',
-	  6: '>= 2.0.0-beta.1',
-	  7: '>= 4.0.0'
-	};
-
-	exports.REVISION_CHANGES = REVISION_CHANGES;
-	var objectType = '[object Object]';
-
-	function HandlebarsEnvironment(helpers, partials, decorators) {
-	  this.helpers = helpers || {};
-	  this.partials = partials || {};
-	  this.decorators = decorators || {};
-
-	  _helpers.registerDefaultHelpers(this);
-	  _decorators.registerDefaultDecorators(this);
-	}
-
-	HandlebarsEnvironment.prototype = {
-	  constructor: HandlebarsEnvironment,
-
-	  logger: _logger2['default'],
-	  log: _logger2['default'].log,
-
-	  registerHelper: function registerHelper(name, fn) {
-	    if (_utils.toString.call(name) === objectType) {
-	      if (fn) {
-	        throw new _exception2['default']('Arg not supported with multiple helpers');
-	      }
-	      _utils.extend(this.helpers, name);
-	    } else {
-	      this.helpers[name] = fn;
-	    }
-	  },
-	  unregisterHelper: function unregisterHelper(name) {
-	    delete this.helpers[name];
-	  },
-
-	  registerPartial: function registerPartial(name, partial) {
-	    if (_utils.toString.call(name) === objectType) {
-	      _utils.extend(this.partials, name);
-	    } else {
-	      if (typeof partial === 'undefined') {
-	        throw new _exception2['default']('Attempting to register a partial called "' + name + '" as undefined');
-	      }
-	      this.partials[name] = partial;
-	    }
-	  },
-	  unregisterPartial: function unregisterPartial(name) {
-	    delete this.partials[name];
-	  },
-
-	  registerDecorator: function registerDecorator(name, fn) {
-	    if (_utils.toString.call(name) === objectType) {
-	      if (fn) {
-	        throw new _exception2['default']('Arg not supported with multiple decorators');
-	      }
-	      _utils.extend(this.decorators, name);
-	    } else {
-	      this.decorators[name] = fn;
-	    }
-	  },
-	  unregisterDecorator: function unregisterDecorator(name) {
-	    delete this.decorators[name];
-	  }
-	};
-
-	var log = _logger2['default'].log;
-
-	exports.log = log;
-	exports.createFrame = _utils.createFrame;
-	exports.logger = _logger2['default'];
-
-/***/ }),
-/* 4 */
-/***/ (function(module, exports) {
-
-	'use strict';
-
-	exports.__esModule = true;
-	exports.extend = extend;
-	exports.indexOf = indexOf;
-	exports.escapeExpression = escapeExpression;
-	exports.isEmpty = isEmpty;
-	exports.createFrame = createFrame;
-	exports.blockParams = blockParams;
-	exports.appendContextPath = appendContextPath;
-	var escape = {
-	  '&': '&amp;',
-	  '<': '&lt;',
-	  '>': '&gt;',
-	  '"': '&quot;',
-	  "'": '&#x27;',
-	  '`': '&#x60;',
-	  '=': '&#x3D;'
-	};
-
-	var badChars = /[&<>"'`=]/g,
-	    possible = /[&<>"'`=]/;
-
-	function escapeChar(chr) {
-	  return escape[chr];
-	}
-
-	function extend(obj /* , ...source */) {
-	  for (var i = 1; i < arguments.length; i++) {
-	    for (var key in arguments[i]) {
-	      if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
-	        obj[key] = arguments[i][key];
-	      }
-	    }
-	  }
-
-	  return obj;
-	}
-
-	var toString = Object.prototype.toString;
-
-	exports.toString = toString;
-	// Sourced from lodash
-	// https://github.com/bestiejs/lodash/blob/master/LICENSE.txt
-	/* eslint-disable func-style */
-	var isFunction = function isFunction(value) {
-	  return typeof value === 'function';
-	};
-	// fallback for older versions of Chrome and Safari
-	/* istanbul ignore next */
-	if (isFunction(/x/)) {
-	  exports.isFunction = isFunction = function (value) {
-	    return typeof value === 'function' && toString.call(value) === '[object Function]';
-	  };
-	}
-	exports.isFunction = isFunction;
-
-	/* eslint-enable func-style */
-
-	/* istanbul ignore next */
-	var isArray = Array.isArray || function (value) {
-	  return value && typeof value === 'object' ? toString.call(value) === '[object Array]' : false;
-	};
-
-	exports.isArray = isArray;
-	// Older IE versions do not directly support indexOf so we must implement our own, sadly.
-
-	function indexOf(array, value) {
-	  for (var i = 0, len = array.length; i < len; i++) {
-	    if (array[i] === value) {
-	      return i;
-	    }
-	  }
-	  return -1;
-	}
-
-	function escapeExpression(string) {
-	  if (typeof string !== 'string') {
-	    // don't escape SafeStrings, since they're already safe
-	    if (string && string.toHTML) {
-	      return string.toHTML();
-	    } else if (string == null) {
-	      return '';
-	    } else if (!string) {
-	      return string + '';
-	    }
-
-	    // Force a string conversion as this will be done by the append regardless and
-	    // the regex test will do this transparently behind the scenes, causing issues if
-	    // an object's to string has escaped characters in it.
-	    string = '' + string;
-	  }
-
-	  if (!possible.test(string)) {
-	    return string;
-	  }
-	  return string.replace(badChars, escapeChar);
-	}
-
-	function isEmpty(value) {
-	  if (!value && value !== 0) {
-	    return true;
-	  } else if (isArray(value) && value.length === 0) {
-	    return true;
-	  } else {
-	    return false;
-	  }
-	}
-
-	function createFrame(object) {
-	  var frame = extend({}, object);
-	  frame._parent = object;
-	  return frame;
-	}
-
-	function blockParams(params, ids) {
-	  params.path = ids;
-	  return params;
-	}
-
-	function appendContextPath(contextPath, id) {
-	  return (contextPath ? contextPath + '.' : '') + id;
-	}
-
-/***/ }),
-/* 5 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _Object$defineProperty = __webpack_require__(6)['default'];
-
-	exports.__esModule = true;
-
-	var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack'];
-
-	function Exception(message, node) {
-	  var loc = node && node.loc,
-	      line = undefined,
-	      column = undefined;
-	  if (loc) {
-	    line = loc.start.line;
-	    column = loc.start.column;
-
-	    message += ' - ' + line + ':' + column;
-	  }
-
-	  var tmp = Error.prototype.constructor.call(this, message);
-
-	  // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
-	  for (var idx = 0; idx < errorProps.length; idx++) {
-	    this[errorProps[idx]] = tmp[errorProps[idx]];
-	  }
-
-	  /* istanbul ignore else */
-	  if (Error.captureStackTrace) {
-	    Error.captureStackTrace(this, Exception);
-	  }
-
-	  try {
-	    if (loc) {
-	      this.lineNumber = line;
-
-	      // Work around issue under safari where we can't directly set the column value
-	      /* istanbul ignore next */
-	      if (_Object$defineProperty) {
-	        Object.defineProperty(this, 'column', {
-	          value: column,
-	          enumerable: true
-	        });
-	      } else {
-	        this.column = column;
-	      }
-	    }
-	  } catch (nop) {
-	    /* Ignore if the browser is very particular */
-	  }
-	}
-
-	Exception.prototype = new Error();
-
-	exports['default'] = Exception;
-	module.exports = exports['default'];
-
-/***/ }),
-/* 6 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	module.exports = { "default": __webpack_require__(7), __esModule: true };
-
-/***/ }),
-/* 7 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	var $ = __webpack_require__(8);
-	module.exports = function defineProperty(it, key, desc){
-	  return $.setDesc(it, key, desc);
-	};
-
-/***/ }),
-/* 8 */
-/***/ (function(module, exports) {
-
-	var $Object = Object;
-	module.exports = {
-	  create:     $Object.create,
-	  getProto:   $Object.getPrototypeOf,
-	  isEnum:     {}.propertyIsEnumerable,
-	  getDesc:    $Object.getOwnPropertyDescriptor,
-	  setDesc:    $Object.defineProperty,
-	  setDescs:   $Object.defineProperties,
-	  getKeys:    $Object.keys,
-	  getNames:   $Object.getOwnPropertyNames,
-	  getSymbols: $Object.getOwnPropertySymbols,
-	  each:       [].forEach
-	};
-
-/***/ }),
-/* 9 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _interopRequireDefault = __webpack_require__(2)['default'];
-
-	exports.__esModule = true;
-	exports.registerDefaultHelpers = registerDefaultHelpers;
-
-	var _helpersBlockHelperMissing = __webpack_require__(10);
-
-	var _helpersBlockHelperMissing2 = _interopRequireDefault(_helpersBlockHelperMissing);
-
-	var _helpersEach = __webpack_require__(11);
-
-	var _helpersEach2 = _interopRequireDefault(_helpersEach);
-
-	var _helpersHelperMissing = __webpack_require__(12);
-
-	var _helpersHelperMissing2 = _interopRequireDefault(_helpersHelperMissing);
-
-	var _helpersIf = __webpack_require__(13);
-
-	var _helpersIf2 = _interopRequireDefault(_helpersIf);
-
-	var _helpersLog = __webpack_require__(14);
-
-	var _helpersLog2 = _interopRequireDefault(_helpersLog);
-
-	var _helpersLookup = __webpack_require__(15);
-
-	var _helpersLookup2 = _interopRequireDefault(_helpersLookup);
-
-	var _helpersWith = __webpack_require__(16);
-
-	var _helpersWith2 = _interopRequireDefault(_helpersWith);
-
-	function registerDefaultHelpers(instance) {
-	  _helpersBlockHelperMissing2['default'](instance);
-	  _helpersEach2['default'](instance);
-	  _helpersHelperMissing2['default'](instance);
-	  _helpersIf2['default'](instance);
-	  _helpersLog2['default'](instance);
-	  _helpersLookup2['default'](instance);
-	  _helpersWith2['default'](instance);
-	}
-
-/***/ }),
-/* 10 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	var _utils = __webpack_require__(4);
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('blockHelperMissing', function (context, options) {
-	    var inverse = options.inverse,
-	        fn = options.fn;
-
-	    if (context === true) {
-	      return fn(this);
-	    } else if (context === false || context == null) {
-	      return inverse(this);
-	    } else if (_utils.isArray(context)) {
-	      if (context.length > 0) {
-	        if (options.ids) {
-	          options.ids = [options.name];
-	        }
-
-	        return instance.helpers.each(context, options);
-	      } else {
-	        return inverse(this);
-	      }
-	    } else {
-	      if (options.data && options.ids) {
-	        var data = _utils.createFrame(options.data);
-	        data.contextPath = _utils.appendContextPath(options.data.contextPath, options.name);
-	        options = { data: data };
-	      }
-
-	      return fn(context, options);
-	    }
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 11 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _interopRequireDefault = __webpack_require__(2)['default'];
-
-	exports.__esModule = true;
-
-	var _utils = __webpack_require__(4);
-
-	var _exception = __webpack_require__(5);
-
-	var _exception2 = _interopRequireDefault(_exception);
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('each', function (context, options) {
-	    if (!options) {
-	      throw new _exception2['default']('Must pass iterator to #each');
-	    }
-
-	    var fn = options.fn,
-	        inverse = options.inverse,
-	        i = 0,
-	        ret = '',
-	        data = undefined,
-	        contextPath = undefined;
-
-	    if (options.data && options.ids) {
-	      contextPath = _utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.';
-	    }
-
-	    if (_utils.isFunction(context)) {
-	      context = context.call(this);
-	    }
-
-	    if (options.data) {
-	      data = _utils.createFrame(options.data);
-	    }
-
-	    function execIteration(field, index, last) {
-	      if (data) {
-	        data.key = field;
-	        data.index = index;
-	        data.first = index === 0;
-	        data.last = !!last;
-
-	        if (contextPath) {
-	          data.contextPath = contextPath + field;
-	        }
-	      }
-
-	      ret = ret + fn(context[field], {
-	        data: data,
-	        blockParams: _utils.blockParams([context[field], field], [contextPath + field, null])
-	      });
-	    }
-
-	    if (context && typeof context === 'object') {
-	      if (_utils.isArray(context)) {
-	        for (var j = context.length; i < j; i++) {
-	          if (i in context) {
-	            execIteration(i, i, i === context.length - 1);
-	          }
-	        }
-	      } else {
-	        var priorKey = undefined;
-
-	        for (var key in context) {
-	          if (context.hasOwnProperty(key)) {
-	            // We're running the iterations one step out of sync so we can detect
-	            // the last iteration without have to scan the object twice and create
-	            // an itermediate keys array.
-	            if (priorKey !== undefined) {
-	              execIteration(priorKey, i - 1);
-	            }
-	            priorKey = key;
-	            i++;
-	          }
-	        }
-	        if (priorKey !== undefined) {
-	          execIteration(priorKey, i - 1, true);
-	        }
-	      }
-	    }
-
-	    if (i === 0) {
-	      ret = inverse(this);
-	    }
-
-	    return ret;
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 12 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _interopRequireDefault = __webpack_require__(2)['default'];
-
-	exports.__esModule = true;
-
-	var _exception = __webpack_require__(5);
-
-	var _exception2 = _interopRequireDefault(_exception);
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('helperMissing', function () /* [args, ]options */{
-	    if (arguments.length === 1) {
-	      // A missing field in a {{foo}} construct.
-	      return undefined;
-	    } else {
-	      // Someone is actually trying to call something, blow up.
-	      throw new _exception2['default']('Missing helper: "' + arguments[arguments.length - 1].name + '"');
-	    }
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 13 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	var _utils = __webpack_require__(4);
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('if', function (conditional, options) {
-	    if (_utils.isFunction(conditional)) {
-	      conditional = conditional.call(this);
-	    }
-
-	    // Default behavior is to render the positive path if the value is truthy and not empty.
-	    // The `includeZero` option may be set to treat the condtional as purely not empty based on the
-	    // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
-	    if (!options.hash.includeZero && !conditional || _utils.isEmpty(conditional)) {
-	      return options.inverse(this);
-	    } else {
-	      return options.fn(this);
-	    }
-	  });
-
-	  instance.registerHelper('unless', function (conditional, options) {
-	    return instance.helpers['if'].call(this, conditional, { fn: options.inverse, inverse: options.fn, hash: options.hash });
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 14 */
-/***/ (function(module, exports) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('log', function () /* message, options */{
-	    var args = [undefined],
-	        options = arguments[arguments.length - 1];
-	    for (var i = 0; i < arguments.length - 1; i++) {
-	      args.push(arguments[i]);
-	    }
-
-	    var level = 1;
-	    if (options.hash.level != null) {
-	      level = options.hash.level;
-	    } else if (options.data && options.data.level != null) {
-	      level = options.data.level;
-	    }
-	    args[0] = level;
-
-	    instance.log.apply(instance, args);
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 15 */
-/***/ (function(module, exports) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('lookup', function (obj, field) {
-	    return obj && obj[field];
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 16 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	var _utils = __webpack_require__(4);
-
-	exports['default'] = function (instance) {
-	  instance.registerHelper('with', function (context, options) {
-	    if (_utils.isFunction(context)) {
-	      context = context.call(this);
-	    }
-
-	    var fn = options.fn;
-
-	    if (!_utils.isEmpty(context)) {
-	      var data = options.data;
-	      if (options.data && options.ids) {
-	        data = _utils.createFrame(options.data);
-	        data.contextPath = _utils.appendContextPath(options.data.contextPath, options.ids[0]);
-	      }
-
-	      return fn(context, {
-	        data: data,
-	        blockParams: _utils.blockParams([context], [data && data.contextPath])
-	      });
-	    } else {
-	      return options.inverse(this);
-	    }
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 17 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _interopRequireDefault = __webpack_require__(2)['default'];
-
-	exports.__esModule = true;
-	exports.registerDefaultDecorators = registerDefaultDecorators;
-
-	var _decoratorsInline = __webpack_require__(18);
-
-	var _decoratorsInline2 = _interopRequireDefault(_decoratorsInline);
-
-	function registerDefaultDecorators(instance) {
-	  _decoratorsInline2['default'](instance);
-	}
-
-/***/ }),
-/* 18 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	var _utils = __webpack_require__(4);
-
-	exports['default'] = function (instance) {
-	  instance.registerDecorator('inline', function (fn, props, container, options) {
-	    var ret = fn;
-	    if (!props.partials) {
-	      props.partials = {};
-	      ret = function (context, options) {
-	        // Create a new partials stack frame prior to exec.
-	        var original = container.partials;
-	        container.partials = _utils.extend({}, original, props.partials);
-	        var ret = fn(context, options);
-	        container.partials = original;
-	        return ret;
-	      };
-	    }
-
-	    props.partials[options.args[0]] = options.fn;
-
-	    return ret;
-	  });
-	};
-
-	module.exports = exports['default'];
-
-/***/ }),
-/* 19 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	exports.__esModule = true;
-
-	var _utils = __webpack_require__(4);
-
-	var logger = {
-	  methodMap: ['debug', 'info', 'warn', 'error'],
-	  level: 'info',
-
-	  // Maps a given level value to the `methodMap` indexes above.
-	  lookupLevel: function lookupLevel(level) {
-	    if (typeof level === 'string') {
-	      var levelMap = _utils.indexOf(logger.methodMap, level.toLowerCase());
-	      if (levelMap >= 0) {
-	        level = levelMap;
-	      } else {
-	        level = parseInt(level, 10);
-	      }
-	    }
-
-	    return level;
-	  },
-
-	  // Can be overridden in the host environment
-	  log: function log(level) {
-	    level = logger.lookupLevel(level);
-
-	    if (typeof console !== 'undefined' && logger.lookupLevel(logger.level) <= level) {
-	      var method = logger.methodMap[level];
-	      if (!console[method]) {
-	        // eslint-disable-line no-console
-	        method = 'log';
-	      }
-
-	      for (var _len = arguments.length, message = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
-	        message[_key - 1] = arguments[_key];
-	      }
-
-	      console[method].apply(console, message); // eslint-disable-line no-console
-	    }
-	  }
-	};
-
-	exports['default'] = logger;
-	module.exports = exports['default'];
-
-/***/ }),
-/* 20 */
-/***/ (function(module, exports) {
-
-	// Build out our basic SafeString type
-	'use strict';
-
-	exports.__esModule = true;
-	function SafeString(string) {
-	  this.string = string;
-	}
-
-	SafeString.prototype.toString = SafeString.prototype.toHTML = function () {
-	  return '' + this.string;
-	};
-
-	exports['default'] = SafeString;
-	module.exports = exports['default'];
-
-/***/ }),
-/* 21 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	'use strict';
-
-	var _Object$seal = __webpack_require__(22)['default'];
-
-	var _interopRequireWildcard = __webpack_require__(1)['default'];
-
-	var _interopRequireDefault = __webpack_require__(2)['default'];
-
-	exports.__esModule = true;
-	exports.checkRevision = checkRevision;
-	exports.template = template;
-	exports.wrapProgram = wrapProgram;
-	exports.resolvePartial = resolvePartial;
-	exports.invokePartial = invokePartial;
-	exports.noop = noop;
-
-	var _utils = __webpack_require__(4);
-
-	var Utils = _interopRequireWildcard(_utils);
-
-	var _exception = __webpack_require__(5);
-
-	var _exception2 = _interopRequireDefault(_exception);
-
-	var _base = __webpack_require__(3);
-
-	function checkRevision(compilerInfo) {
-	  var compilerRevision = compilerInfo && compilerInfo[0] || 1,
-	      currentRevision = _base.COMPILER_REVISION;
-
-	  if (compilerRevision !== currentRevision) {
-	    if (compilerRevision < currentRevision) {
-	      var runtimeVersions = _base.REVISION_CHANGES[currentRevision],
-	          compilerVersions = _base.REVISION_CHANGES[compilerRevision];
-	      throw new _exception2['default']('Template was precompiled with an older version of Handlebars than the current runtime. ' + 'Please update your precompiler to a newer version (' + runtimeVersions + ') or downgrade your runtime to an older version (' + compilerVersions + ').');
-	    } else {
-	      // Use the embedded version info since the runtime doesn't know about this revision yet
-	      throw new _exception2['default']('Template was precompiled with a newer version of Handlebars than the current runtime. ' + 'Please update your runtime to a newer version (' + compilerInfo[1] + ').');
-	    }
-	  }
-	}
-
-	function template(templateSpec, env) {
-	  /* istanbul ignore next */
-	  if (!env) {
-	    throw new _exception2['default']('No environment passed to template');
-	  }
-	  if (!templateSpec || !templateSpec.main) {
-	    throw new _exception2['default']('Unknown template object: ' + typeof templateSpec);
-	  }
-
-	  templateSpec.main.decorator = templateSpec.main_d;
-
-	  // Note: Using env.VM references rather than local var references throughout this section to allow
-	  // for external users to override these as psuedo-supported APIs.
-	  env.VM.checkRevision(templateSpec.compiler);
-
-	  function invokePartialWrapper(partial, context, options) {
-	    if (options.hash) {
-	      context = Utils.extend({}, context, options.hash);
-	      if (options.ids) {
-	        options.ids[0] = true;
-	      }
-	    }
-
-	    partial = env.VM.resolvePartial.call(this, partial, context, options);
-	    var result = env.VM.invokePartial.call(this, partial, context, options);
-
-	    if (result == null && env.compile) {
-	      options.partials[options.name] = env.compile(partial, templateSpec.compilerOptions, env);
-	      result = options.partials[options.name](context, options);
-	    }
-	    if (result != null) {
-	      if (options.indent) {
-	        var lines = result.split('\n');
-	        for (var i = 0, l = lines.length; i < l; i++) {
-	          if (!lines[i] && i + 1 === l) {
-	            break;
-	          }
-
-	          lines[i] = options.indent + lines[i];
-	        }
-	        result = lines.join('\n');
-	      }
-	      return result;
-	    } else {
-	      throw new _exception2['default']('The partial ' + options.name + ' could not be compiled when running in runtime-only mode');
-	    }
-	  }
-
-	  // Just add water
-	  var container = {
-	    strict: function strict(obj, name) {
-	      if (!(name in obj)) {
-	        throw new _exception2['default']('"' + name + '" not defined in ' + obj);
-	      }
-	      return obj[name];
-	    },
-	    lookup: function lookup(depths, name) {
-	      var len = depths.length;
-	      for (var i = 0; i < len; i++) {
-	        if (depths[i] && depths[i][name] != null) {
-	          return depths[i][name];
-	        }
-	      }
-	    },
-	    lambda: function lambda(current, context) {
-	      return typeof current === 'function' ? current.call(context) : current;
-	    },
-
-	    escapeExpression: Utils.escapeExpression,
-	    invokePartial: invokePartialWrapper,
-
-	    fn: function fn(i) {
-	      var ret = templateSpec[i];
-	      ret.decorator = templateSpec[i + '_d'];
-	      return ret;
-	    },
-
-	    programs: [],
-	    program: function program(i, data, declaredBlockParams, blockParams, depths) {
-	      var programWrapper = this.programs[i],
-	          fn = this.fn(i);
-	      if (data || depths || blockParams || declaredBlockParams) {
-	        programWrapper = wrapProgram(this, i, fn, data, declaredBlockParams, blockParams, depths);
-	      } else if (!programWrapper) {
-	        programWrapper = this.programs[i] = wrapProgram(this, i, fn);
-	      }
-	      return programWrapper;
-	    },
-
-	    data: function data(value, depth) {
-	      while (value && depth--) {
-	        value = value._parent;
-	      }
-	      return value;
-	    },
-	    merge: function merge(param, common) {
-	      var obj = param || common;
-
-	      if (param && common && param !== common) {
-	        obj = Utils.extend({}, common, param);
-	      }
-
-	      return obj;
-	    },
-	    // An empty object to use as replacement for null-contexts
-	    nullContext: _Object$seal({}),
-
-	    noop: env.VM.noop,
-	    compilerInfo: templateSpec.compiler
-	  };
-
-	  function ret(context) {
-	    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-	    var data = options.data;
-
-	    ret._setup(options);
-	    if (!options.partial && templateSpec.useData) {
-	      data = initData(context, data);
-	    }
-	    var depths = undefined,
-	        blockParams = templateSpec.useBlockParams ? [] : undefined;
-	    if (templateSpec.useDepths) {
-	      if (options.depths) {
-	        depths = context != options.depths[0] ? [context].concat(options.depths) : options.depths;
-	      } else {
-	        depths = [context];
-	      }
-	    }
-
-	    function main(context /*, options*/) {
-	      return '' + templateSpec.main(container, context, container.helpers, container.partials, data, blockParams, depths);
-	    }
-	    main = executeDecorators(templateSpec.main, main, container, options.depths || [], data, blockParams);
-	    return main(context, options);
-	  }
-	  ret.isTop = true;
-
-	  ret._setup = function (options) {
-	    if (!options.partial) {
-	      container.helpers = container.merge(options.helpers, env.helpers);
-
-	      if (templateSpec.usePartial) {
-	        container.partials = container.merge(options.partials, env.partials);
-	      }
-	      if (templateSpec.usePartial || templateSpec.useDecorators) {
-	        container.decorators = container.merge(options.decorators, env.decorators);
-	      }
-	    } else {
-	      container.helpers = options.helpers;
-	      container.partials = options.partials;
-	      container.decorators = options.decorators;
-	    }
-	  };
-
-	  ret._child = function (i, data, blockParams, depths) {
-	    if (templateSpec.useBlockParams && !blockParams) {
-	      throw new _exception2['default']('must pass block params');
-	    }
-	    if (templateSpec.useDepths && !depths) {
-	      throw new _exception2['default']('must pass parent depths');
-	    }
-
-	    return wrapProgram(container, i, templateSpec[i], data, 0, blockParams, depths);
-	  };
-	  return ret;
-	}
-
-	function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, depths) {
-	  function prog(context) {
-	    var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-	    var currentDepths = depths;
-	    if (depths && context != depths[0] && !(context === container.nullContext && depths[0] === null)) {
-	      currentDepths = [context].concat(depths);
-	    }
-
-	    return fn(container, context, container.helpers, container.partials, options.data || data, blockParams && [options.blockParams].concat(blockParams), currentDepths);
-	  }
-
-	  prog = executeDecorators(fn, prog, container, depths, data, blockParams);
-
-	  prog.program = i;
-	  prog.depth = depths ? depths.length : 0;
-	  prog.blockParams = declaredBlockParams || 0;
-	  return prog;
-	}
-
-	function resolvePartial(partial, context, options) {
-	  if (!partial) {
-	    if (options.name === '@partial-block') {
-	      partial = options.data['partial-block'];
-	    } else {
-	      partial = options.partials[options.name];
-	    }
-	  } else if (!partial.call && !options.name) {
-	    // This is a dynamic partial that returned a string
-	    options.name = partial;
-	    partial = options.partials[partial];
-	  }
-	  return partial;
-	}
-
-	function invokePartial(partial, context, options) {
-	  // Use the current closure context to save the partial-block if this partial
-	  var currentPartialBlock = options.data && options.data['partial-block'];
-	  options.partial = true;
-	  if (options.ids) {
-	    options.data.contextPath = options.ids[0] || options.data.contextPath;
-	  }
-
-	  var partialBlock = undefined;
-	  if (options.fn && options.fn !== noop) {
-	    (function () {
-	      options.data = _base.createFrame(options.data);
-	      // Wrapper function to get access to currentPartialBlock from the closure
-	      var fn = options.fn;
-	      partialBlock = options.data['partial-block'] = function partialBlockWrapper(context) {
-	        var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
-
-	        // Restore the partial-block from the closure for the execution of the block
-	        // i.e. the part inside the block of the partial call.
-	        options.data = _base.createFrame(options.data);
-	        options.data['partial-block'] = currentPartialBlock;
-	        return fn(context, options);
-	      };
-	      if (fn.partials) {
-	        options.partials = Utils.extend({}, options.partials, fn.partials);
-	      }
-	    })();
-	  }
-
-	  if (partial === undefined && partialBlock) {
-	    partial = partialBlock;
-	  }
-
-	  if (partial === undefined) {
-	    throw new _exception2['default']('The partial ' + options.name + ' could not be found');
-	  } else if (partial instanceof Function) {
-	    return partial(context, options);
-	  }
-	}
-
-	function noop() {
-	  return '';
-	}
-
-	function initData(context, data) {
-	  if (!data || !('root' in data)) {
-	    data = data ? _base.createFrame(data) : {};
-	    data.root = context;
-	  }
-	  return data;
-	}
-
-	function executeDecorators(fn, prog, container, depths, data, blockParams) {
-	  if (fn.decorator) {
-	    var props = {};
-	    prog = fn.decorator(prog, props, container, depths && depths[0], data, blockParams, depths);
-	    Utils.extend(prog, props);
-	  }
-	  return prog;
-	}
-
-/***/ }),
-/* 22 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	module.exports = { "default": __webpack_require__(23), __esModule: true };
-
-/***/ }),
-/* 23 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	__webpack_require__(24);
-	module.exports = __webpack_require__(29).Object.seal;
-
-/***/ }),
-/* 24 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	// 19.1.2.17 Object.seal(O)
-	var isObject = __webpack_require__(25);
-
-	__webpack_require__(26)('seal', function($seal){
-	  return function seal(it){
-	    return $seal && isObject(it) ? $seal(it) : it;
-	  };
-	});
-
-/***/ }),
-/* 25 */
-/***/ (function(module, exports) {
-
-	module.exports = function(it){
-	  return typeof it === 'object' ? it !== null : typeof it === 'function';
-	};
-
-/***/ }),
-/* 26 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	// most Object methods by ES6 should accept primitives
-	var $export = __webpack_require__(27)
-	  , core    = __webpack_require__(29)
-	  , fails   = __webpack_require__(32);
-	module.exports = function(KEY, exec){
-	  var fn  = (core.Object || {})[KEY] || Object[KEY]
-	    , exp = {};
-	  exp[KEY] = exec(fn);
-	  $export($export.S + $export.F * fails(function(){ fn(1); }), 'Object', exp);
-	};
-
-/***/ }),
-/* 27 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	var global    = __webpack_require__(28)
-	  , core      = __webpack_require__(29)
-	  , ctx       = __webpack_require__(30)
-	  , PROTOTYPE = 'prototype';
-
-	var $export = function(type, name, source){
-	  var IS_FORCED = type & $export.F
-	    , IS_GLOBAL = type & $export.G
-	    , IS_STATIC = type & $export.S
-	    , IS_PROTO  = type & $export.P
-	    , IS_BIND   = type & $export.B
-	    , IS_WRAP   = type & $export.W
-	    , exports   = IS_GLOBAL ? core : core[name] || (core[name] = {})
-	    , target    = IS_GLOBAL ? global : IS_STATIC ? global[name] : (global[name] || {})[PROTOTYPE]
-	    , key, own, out;
-	  if(IS_GLOBAL)source = name;
-	  for(key in source){
-	    // contains in native
-	    own = !IS_FORCED && target && key in target;
-	    if(own && key in exports)continue;
-	    // export native or passed
-	    out = own ? target[key] : source[key];
-	    // prevent global pollution for namespaces
-	    exports[key] = IS_GLOBAL && typeof target[key] != 'function' ? source[key]
-	    // bind timers to global for call from export context
-	    : IS_BIND && own ? ctx(out, global)
-	    // wrap global constructors for prevent change them in library
-	    : IS_WRAP && target[key] == out ? (function(C){
-	      var F = function(param){
-	        return this instanceof C ? new C(param) : C(param);
-	      };
-	      F[PROTOTYPE] = C[PROTOTYPE];
-	      return F;
-	    // make static versions for prototype methods
-	    })(out) : IS_PROTO && typeof out == 'function' ? ctx(Function.call, out) : out;
-	    if(IS_PROTO)(exports[PROTOTYPE] || (exports[PROTOTYPE] = {}))[key] = out;
-	  }
-	};
-	// type bitmap
-	$export.F = 1;  // forced
-	$export.G = 2;  // global
-	$export.S = 4;  // static
-	$export.P = 8;  // proto
-	$export.B = 16; // bind
-	$export.W = 32; // wrap
-	module.exports = $export;
-
-/***/ }),
-/* 28 */
-/***/ (function(module, exports) {
-
-	// https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
-	var global = module.exports = typeof window != 'undefined' && window.Math == Math
-	  ? window : typeof self != 'undefined' && self.Math == Math ? self : Function('return this')();
-	if(typeof __g == 'number')__g = global; // eslint-disable-line no-undef
-
-/***/ }),
-/* 29 */
-/***/ (function(module, exports) {
-
-	var core = module.exports = {version: '1.2.6'};
-	if(typeof __e == 'number')__e = core; // eslint-disable-line no-undef
-
-/***/ }),
-/* 30 */
-/***/ (function(module, exports, __webpack_require__) {
-
-	// optional / simple context binding
-	var aFunction = __webpack_require__(31);
-	module.exports = function(fn, that, length){
-	  aFunction(fn);
-	  if(that === undefined)return fn;
-	  switch(length){
-	    case 1: return function(a){
-	      return fn.call(that, a);
-	    };
-	    case 2: return function(a, b){
-	      return fn.call(that, a, b);
-	    };
-	    case 3: return function(a, b, c){
-	      return fn.call(that, a, b, c);
-	    };
-	  }
-	  return function(/* ...args */){
-	    return fn.apply(that, arguments);
-	  };
-	};
-
-/***/ }),
-/* 31 */
-/***/ (function(module, exports) {
-
-	module.exports = function(it){
-	  if(typeof it != 'function')throw TypeError(it + ' is not a function!');
-	  return it;
-	};
-
-/***/ }),
-/* 32 */
-/***/ (function(module, exports) {
-
-	module.exports = function(exec){
-	  try {
-	    return !!exec();
-	  } catch(e){
-	    return true;
-	  }
-	};
-
-/***/ }),
-/* 33 */
-/***/ (function(module, exports) {
-
-	/* WEBPACK VAR INJECTION */(function(global) {/* global window */
-	'use strict';
-
-	exports.__esModule = true;
-
-	exports['default'] = function (Handlebars) {
-	  /* istanbul ignore next */
-	  var root = typeof global !== 'undefined' ? global : window,
-	      $Handlebars = root.Handlebars;
-	  /* istanbul ignore next */
-	  Handlebars.noConflict = function () {
-	    if (root.Handlebars === Handlebars) {
-	      root.Handlebars = $Handlebars;
-	    }
-	    return Handlebars;
-	  };
-	};
-
-	module.exports = exports['default'];
-	/* WEBPACK VAR INJECTION */}.call(exports, (function() { return this; }())))
-
-/***/ })
-/******/ ])
-});
-;
+        /***/
+      },
+      /* 1 */
+      /***/ function(module, exports) {
+        'use strict'
+
+        exports['default'] = function(obj) {
+          if (obj && obj.__esModule) {
+            return obj
+          } else {
+            var newObj = {}
+
+            if (obj != null) {
+              for (var key in obj) {
+                if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]
+              }
+            }
+
+            newObj['default'] = obj
+            return newObj
+          }
+        }
+
+        exports.__esModule = true
+
+        /***/
+      },
+      /* 2 */
+      /***/ function(module, exports) {
+        'use strict'
+
+        exports['default'] = function(obj) {
+          return obj && obj.__esModule
+            ? obj
+            : {
+                default: obj
+              }
+        }
+
+        exports.__esModule = true
+
+        /***/
+      },
+      /* 3 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _interopRequireDefault = __webpack_require__(2)['default']
+
+        exports.__esModule = true
+        exports.HandlebarsEnvironment = HandlebarsEnvironment
+
+        var _utils = __webpack_require__(4)
+
+        var _exception = __webpack_require__(5)
+
+        var _exception2 = _interopRequireDefault(_exception)
+
+        var _helpers = __webpack_require__(9)
+
+        var _decorators = __webpack_require__(17)
+
+        var _logger = __webpack_require__(19)
+
+        var _logger2 = _interopRequireDefault(_logger)
+
+        var VERSION = '4.0.10'
+        exports.VERSION = VERSION
+        var COMPILER_REVISION = 7
+
+        exports.COMPILER_REVISION = COMPILER_REVISION
+        var REVISION_CHANGES = {
+          1: '<= 1.0.rc.2', // 1.0.rc.2 is actually rev2 but doesn't report it
+          2: '== 1.0.0-rc.3',
+          3: '== 1.0.0-rc.4',
+          4: '== 1.x.x',
+          5: '== 2.0.0-alpha.x',
+          6: '>= 2.0.0-beta.1',
+          7: '>= 4.0.0'
+        }
+
+        exports.REVISION_CHANGES = REVISION_CHANGES
+        var objectType = '[object Object]'
+
+        function HandlebarsEnvironment(helpers, partials, decorators) {
+          this.helpers = helpers || {}
+          this.partials = partials || {}
+          this.decorators = decorators || {}
+
+          _helpers.registerDefaultHelpers(this)
+          _decorators.registerDefaultDecorators(this)
+        }
+
+        HandlebarsEnvironment.prototype = {
+          constructor: HandlebarsEnvironment,
+
+          logger: _logger2['default'],
+          log: _logger2['default'].log,
+
+          registerHelper: function registerHelper(name, fn) {
+            if (_utils.toString.call(name) === objectType) {
+              if (fn) {
+                throw new _exception2['default']('Arg not supported with multiple helpers')
+              }
+              _utils.extend(this.helpers, name)
+            } else {
+              this.helpers[name] = fn
+            }
+          },
+          unregisterHelper: function unregisterHelper(name) {
+            delete this.helpers[name]
+          },
+
+          registerPartial: function registerPartial(name, partial) {
+            if (_utils.toString.call(name) === objectType) {
+              _utils.extend(this.partials, name)
+            } else {
+              if (typeof partial === 'undefined') {
+                throw new _exception2['default']('Attempting to register a partial called "' + name + '" as undefined')
+              }
+              this.partials[name] = partial
+            }
+          },
+          unregisterPartial: function unregisterPartial(name) {
+            delete this.partials[name]
+          },
+
+          registerDecorator: function registerDecorator(name, fn) {
+            if (_utils.toString.call(name) === objectType) {
+              if (fn) {
+                throw new _exception2['default']('Arg not supported with multiple decorators')
+              }
+              _utils.extend(this.decorators, name)
+            } else {
+              this.decorators[name] = fn
+            }
+          },
+          unregisterDecorator: function unregisterDecorator(name) {
+            delete this.decorators[name]
+          }
+        }
+
+        var log = _logger2['default'].log
+
+        exports.log = log
+        exports.createFrame = _utils.createFrame
+        exports.logger = _logger2['default']
+
+        /***/
+      },
+      /* 4 */
+      /***/ function(module, exports) {
+        'use strict'
+
+        exports.__esModule = true
+        exports.extend = extend
+        exports.indexOf = indexOf
+        exports.escapeExpression = escapeExpression
+        exports.isEmpty = isEmpty
+        exports.createFrame = createFrame
+        exports.blockParams = blockParams
+        exports.appendContextPath = appendContextPath
+        var escape = {
+          '&': '&amp;',
+          '<': '&lt;',
+          '>': '&gt;',
+          '"': '&quot;',
+          "'": '&#x27;',
+          '`': '&#x60;',
+          '=': '&#x3D;'
+        }
+
+        var badChars = /[&<>"'`=]/g,
+          possible = /[&<>"'`=]/
+
+        function escapeChar(chr) {
+          return escape[chr]
+        }
+
+        function extend(obj /* , ...source */) {
+          for (var i = 1; i < arguments.length; i++) {
+            for (var key in arguments[i]) {
+              if (Object.prototype.hasOwnProperty.call(arguments[i], key)) {
+                obj[key] = arguments[i][key]
+              }
+            }
+          }
+
+          return obj
+        }
+
+        var toString = Object.prototype.toString
+
+        exports.toString = toString
+        // Sourced from lodash
+        // https://github.com/bestiejs/lodash/blob/master/LICENSE.txt
+        /* eslint-disable func-style */
+        var isFunction = function isFunction(value) {
+          return typeof value === 'function'
+        }
+        // fallback for older versions of Chrome and Safari
+        /* istanbul ignore next */
+        if (isFunction(/x/)) {
+          exports.isFunction = isFunction = function(value) {
+            return typeof value === 'function' && toString.call(value) === '[object Function]'
+          }
+        }
+        exports.isFunction = isFunction
+
+        /* eslint-enable func-style */
+
+        /* istanbul ignore next */
+        var isArray =
+          Array.isArray ||
+          function(value) {
+            return value && typeof value === 'object' ? toString.call(value) === '[object Array]' : false
+          }
+
+        exports.isArray = isArray
+        // Older IE versions do not directly support indexOf so we must implement our own, sadly.
+
+        function indexOf(array, value) {
+          for (var i = 0, len = array.length; i < len; i++) {
+            if (array[i] === value) {
+              return i
+            }
+          }
+          return -1
+        }
+
+        function escapeExpression(string) {
+          if (typeof string !== 'string') {
+            // don't escape SafeStrings, since they're already safe
+            if (string && string.toHTML) {
+              return string.toHTML()
+            } else if (string == null) {
+              return ''
+            } else if (!string) {
+              return string + ''
+            }
+
+            // Force a string conversion as this will be done by the append regardless and
+            // the regex test will do this transparently behind the scenes, causing issues if
+            // an object's to string has escaped characters in it.
+            string = '' + string
+          }
+
+          if (!possible.test(string)) {
+            return string
+          }
+          return string.replace(badChars, escapeChar)
+        }
+
+        function isEmpty(value) {
+          if (!value && value !== 0) {
+            return true
+          } else if (isArray(value) && value.length === 0) {
+            return true
+          } else {
+            return false
+          }
+        }
+
+        function createFrame(object) {
+          var frame = extend({}, object)
+          frame._parent = object
+          return frame
+        }
+
+        function blockParams(params, ids) {
+          params.path = ids
+          return params
+        }
+
+        function appendContextPath(contextPath, id) {
+          return (contextPath ? contextPath + '.' : '') + id
+        }
+
+        /***/
+      },
+      /* 5 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _Object$defineProperty = __webpack_require__(6)['default']
+
+        exports.__esModule = true
+
+        var errorProps = ['description', 'fileName', 'lineNumber', 'message', 'name', 'number', 'stack']
+
+        function Exception(message, node) {
+          var loc = node && node.loc,
+            line = undefined,
+            column = undefined
+          if (loc) {
+            line = loc.start.line
+            column = loc.start.column
+
+            message += ' - ' + line + ':' + column
+          }
+
+          var tmp = Error.prototype.constructor.call(this, message)
+
+          // Unfortunately errors are not enumerable in Chrome (at least), so `for prop in tmp` doesn't work.
+          for (var idx = 0; idx < errorProps.length; idx++) {
+            this[errorProps[idx]] = tmp[errorProps[idx]]
+          }
+
+          /* istanbul ignore else */
+          if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, Exception)
+          }
+
+          try {
+            if (loc) {
+              this.lineNumber = line
+
+              // Work around issue under safari where we can't directly set the column value
+              /* istanbul ignore next */
+              if (_Object$defineProperty) {
+                Object.defineProperty(this, 'column', {
+                  value: column,
+                  enumerable: true
+                })
+              } else {
+                this.column = column
+              }
+            }
+          } catch (nop) {
+            /* Ignore if the browser is very particular */
+          }
+        }
+
+        Exception.prototype = new Error()
+
+        exports['default'] = Exception
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 6 */
+      /***/ function(module, exports, __webpack_require__) {
+        module.exports = { default: __webpack_require__(7), __esModule: true }
+
+        /***/
+      },
+      /* 7 */
+      /***/ function(module, exports, __webpack_require__) {
+        var $ = __webpack_require__(8)
+        module.exports = function defineProperty(it, key, desc) {
+          return $.setDesc(it, key, desc)
+        }
+
+        /***/
+      },
+      /* 8 */
+      /***/ function(module, exports) {
+        var $Object = Object
+        module.exports = {
+          create: $Object.create,
+          getProto: $Object.getPrototypeOf,
+          isEnum: {}.propertyIsEnumerable,
+          getDesc: $Object.getOwnPropertyDescriptor,
+          setDesc: $Object.defineProperty,
+          setDescs: $Object.defineProperties,
+          getKeys: $Object.keys,
+          getNames: $Object.getOwnPropertyNames,
+          getSymbols: $Object.getOwnPropertySymbols,
+          each: [].forEach
+        }
+
+        /***/
+      },
+      /* 9 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _interopRequireDefault = __webpack_require__(2)['default']
+
+        exports.__esModule = true
+        exports.registerDefaultHelpers = registerDefaultHelpers
+
+        var _helpersBlockHelperMissing = __webpack_require__(10)
+
+        var _helpersBlockHelperMissing2 = _interopRequireDefault(_helpersBlockHelperMissing)
+
+        var _helpersEach = __webpack_require__(11)
+
+        var _helpersEach2 = _interopRequireDefault(_helpersEach)
+
+        var _helpersHelperMissing = __webpack_require__(12)
+
+        var _helpersHelperMissing2 = _interopRequireDefault(_helpersHelperMissing)
+
+        var _helpersIf = __webpack_require__(13)
+
+        var _helpersIf2 = _interopRequireDefault(_helpersIf)
+
+        var _helpersLog = __webpack_require__(14)
+
+        var _helpersLog2 = _interopRequireDefault(_helpersLog)
+
+        var _helpersLookup = __webpack_require__(15)
+
+        var _helpersLookup2 = _interopRequireDefault(_helpersLookup)
+
+        var _helpersWith = __webpack_require__(16)
+
+        var _helpersWith2 = _interopRequireDefault(_helpersWith)
+
+        function registerDefaultHelpers(instance) {
+          _helpersBlockHelperMissing2['default'](instance)
+          _helpersEach2['default'](instance)
+          _helpersHelperMissing2['default'](instance)
+          _helpersIf2['default'](instance)
+          _helpersLog2['default'](instance)
+          _helpersLookup2['default'](instance)
+          _helpersWith2['default'](instance)
+        }
+
+        /***/
+      },
+      /* 10 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        exports.__esModule = true
+
+        var _utils = __webpack_require__(4)
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('blockHelperMissing', function(context, options) {
+            var inverse = options.inverse,
+              fn = options.fn
+
+            if (context === true) {
+              return fn(this)
+            } else if (context === false || context == null) {
+              return inverse(this)
+            } else if (_utils.isArray(context)) {
+              if (context.length > 0) {
+                if (options.ids) {
+                  options.ids = [options.name]
+                }
+
+                return instance.helpers.each(context, options)
+              } else {
+                return inverse(this)
+              }
+            } else {
+              if (options.data && options.ids) {
+                var data = _utils.createFrame(options.data)
+                data.contextPath = _utils.appendContextPath(options.data.contextPath, options.name)
+                options = { data: data }
+              }
+
+              return fn(context, options)
+            }
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 11 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _interopRequireDefault = __webpack_require__(2)['default']
+
+        exports.__esModule = true
+
+        var _utils = __webpack_require__(4)
+
+        var _exception = __webpack_require__(5)
+
+        var _exception2 = _interopRequireDefault(_exception)
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('each', function(context, options) {
+            if (!options) {
+              throw new _exception2['default']('Must pass iterator to #each')
+            }
+
+            var fn = options.fn,
+              inverse = options.inverse,
+              i = 0,
+              ret = '',
+              data = undefined,
+              contextPath = undefined
+
+            if (options.data && options.ids) {
+              contextPath = _utils.appendContextPath(options.data.contextPath, options.ids[0]) + '.'
+            }
+
+            if (_utils.isFunction(context)) {
+              context = context.call(this)
+            }
+
+            if (options.data) {
+              data = _utils.createFrame(options.data)
+            }
+
+            function execIteration(field, index, last) {
+              if (data) {
+                data.key = field
+                data.index = index
+                data.first = index === 0
+                data.last = !!last
+
+                if (contextPath) {
+                  data.contextPath = contextPath + field
+                }
+              }
+
+              ret =
+                ret +
+                fn(context[field], {
+                  data: data,
+                  blockParams: _utils.blockParams([context[field], field], [contextPath + field, null])
+                })
+            }
+
+            if (context && typeof context === 'object') {
+              if (_utils.isArray(context)) {
+                for (var j = context.length; i < j; i++) {
+                  if (i in context) {
+                    execIteration(i, i, i === context.length - 1)
+                  }
+                }
+              } else {
+                var priorKey = undefined
+
+                for (var key in context) {
+                  if (context.hasOwnProperty(key)) {
+                    // We're running the iterations one step out of sync so we can detect
+                    // the last iteration without have to scan the object twice and create
+                    // an itermediate keys array.
+                    if (priorKey !== undefined) {
+                      execIteration(priorKey, i - 1)
+                    }
+                    priorKey = key
+                    i++
+                  }
+                }
+                if (priorKey !== undefined) {
+                  execIteration(priorKey, i - 1, true)
+                }
+              }
+            }
+
+            if (i === 0) {
+              ret = inverse(this)
+            }
+
+            return ret
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 12 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _interopRequireDefault = __webpack_require__(2)['default']
+
+        exports.__esModule = true
+
+        var _exception = __webpack_require__(5)
+
+        var _exception2 = _interopRequireDefault(_exception)
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('helperMissing', function() /* [args, ]options */ {
+            if (arguments.length === 1) {
+              // A missing field in a {{foo}} construct.
+              return undefined
+            } else {
+              // Someone is actually trying to call something, blow up.
+              throw new _exception2['default']('Missing helper: "' + arguments[arguments.length - 1].name + '"')
+            }
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 13 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        exports.__esModule = true
+
+        var _utils = __webpack_require__(4)
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('if', function(conditional, options) {
+            if (_utils.isFunction(conditional)) {
+              conditional = conditional.call(this)
+            }
+
+            // Default behavior is to render the positive path if the value is truthy and not empty.
+            // The `includeZero` option may be set to treat the condtional as purely not empty based on the
+            // behavior of isEmpty. Effectively this determines if 0 is handled by the positive path or negative.
+            if ((!options.hash.includeZero && !conditional) || _utils.isEmpty(conditional)) {
+              return options.inverse(this)
+            } else {
+              return options.fn(this)
+            }
+          })
+
+          instance.registerHelper('unless', function(conditional, options) {
+            return instance.helpers['if'].call(this, conditional, {
+              fn: options.inverse,
+              inverse: options.fn,
+              hash: options.hash
+            })
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 14 */
+      /***/ function(module, exports) {
+        'use strict'
+
+        exports.__esModule = true
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('log', function() /* message, options */ {
+            var args = [undefined],
+              options = arguments[arguments.length - 1]
+            for (var i = 0; i < arguments.length - 1; i++) {
+              args.push(arguments[i])
+            }
+
+            var level = 1
+            if (options.hash.level != null) {
+              level = options.hash.level
+            } else if (options.data && options.data.level != null) {
+              level = options.data.level
+            }
+            args[0] = level
+
+            instance.log.apply(instance, args)
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 15 */
+      /***/ function(module, exports) {
+        'use strict'
+
+        exports.__esModule = true
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('lookup', function(obj, field) {
+            return obj && obj[field]
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 16 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        exports.__esModule = true
+
+        var _utils = __webpack_require__(4)
+
+        exports['default'] = function(instance) {
+          instance.registerHelper('with', function(context, options) {
+            if (_utils.isFunction(context)) {
+              context = context.call(this)
+            }
+
+            var fn = options.fn
+
+            if (!_utils.isEmpty(context)) {
+              var data = options.data
+              if (options.data && options.ids) {
+                data = _utils.createFrame(options.data)
+                data.contextPath = _utils.appendContextPath(options.data.contextPath, options.ids[0])
+              }
+
+              return fn(context, {
+                data: data,
+                blockParams: _utils.blockParams([context], [data && data.contextPath])
+              })
+            } else {
+              return options.inverse(this)
+            }
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 17 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _interopRequireDefault = __webpack_require__(2)['default']
+
+        exports.__esModule = true
+        exports.registerDefaultDecorators = registerDefaultDecorators
+
+        var _decoratorsInline = __webpack_require__(18)
+
+        var _decoratorsInline2 = _interopRequireDefault(_decoratorsInline)
+
+        function registerDefaultDecorators(instance) {
+          _decoratorsInline2['default'](instance)
+        }
+
+        /***/
+      },
+      /* 18 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        exports.__esModule = true
+
+        var _utils = __webpack_require__(4)
+
+        exports['default'] = function(instance) {
+          instance.registerDecorator('inline', function(fn, props, container, options) {
+            var ret = fn
+            if (!props.partials) {
+              props.partials = {}
+              ret = function(context, options) {
+                // Create a new partials stack frame prior to exec.
+                var original = container.partials
+                container.partials = _utils.extend({}, original, props.partials)
+                var ret = fn(context, options)
+                container.partials = original
+                return ret
+              }
+            }
+
+            props.partials[options.args[0]] = options.fn
+
+            return ret
+          })
+        }
+
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 19 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        exports.__esModule = true
+
+        var _utils = __webpack_require__(4)
+
+        var logger = {
+          methodMap: ['debug', 'info', 'warn', 'error'],
+          level: 'info',
+
+          // Maps a given level value to the `methodMap` indexes above.
+          lookupLevel: function lookupLevel(level) {
+            if (typeof level === 'string') {
+              var levelMap = _utils.indexOf(logger.methodMap, level.toLowerCase())
+              if (levelMap >= 0) {
+                level = levelMap
+              } else {
+                level = parseInt(level, 10)
+              }
+            }
+
+            return level
+          },
+
+          // Can be overridden in the host environment
+          log: function log(level) {
+            level = logger.lookupLevel(level)
+
+            if (typeof console !== 'undefined' && logger.lookupLevel(logger.level) <= level) {
+              var method = logger.methodMap[level]
+              if (!console[method]) {
+                // eslint-disable-line no-console
+                method = 'log'
+              }
+
+              for (
+                var _len = arguments.length, message = Array(_len > 1 ? _len - 1 : 0), _key = 1;
+                _key < _len;
+                _key++
+              ) {
+                message[_key - 1] = arguments[_key]
+              }
+
+              console[method].apply(console, message) // eslint-disable-line no-console
+            }
+          }
+        }
+
+        exports['default'] = logger
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 20 */
+      /***/ function(module, exports) {
+        // Build out our basic SafeString type
+        'use strict'
+
+        exports.__esModule = true
+        function SafeString(string) {
+          this.string = string
+        }
+
+        SafeString.prototype.toString = SafeString.prototype.toHTML = function() {
+          return '' + this.string
+        }
+
+        exports['default'] = SafeString
+        module.exports = exports['default']
+
+        /***/
+      },
+      /* 21 */
+      /***/ function(module, exports, __webpack_require__) {
+        'use strict'
+
+        var _Object$seal = __webpack_require__(22)['default']
+
+        var _interopRequireWildcard = __webpack_require__(1)['default']
+
+        var _interopRequireDefault = __webpack_require__(2)['default']
+
+        exports.__esModule = true
+        exports.checkRevision = checkRevision
+        exports.template = template
+        exports.wrapProgram = wrapProgram
+        exports.resolvePartial = resolvePartial
+        exports.invokePartial = invokePartial
+        exports.noop = noop
+
+        var _utils = __webpack_require__(4)
+
+        var Utils = _interopRequireWildcard(_utils)
+
+        var _exception = __webpack_require__(5)
+
+        var _exception2 = _interopRequireDefault(_exception)
+
+        var _base = __webpack_require__(3)
+
+        function checkRevision(compilerInfo) {
+          var compilerRevision = (compilerInfo && compilerInfo[0]) || 1,
+            currentRevision = _base.COMPILER_REVISION
+
+          if (compilerRevision !== currentRevision) {
+            if (compilerRevision < currentRevision) {
+              var runtimeVersions = _base.REVISION_CHANGES[currentRevision],
+                compilerVersions = _base.REVISION_CHANGES[compilerRevision]
+              throw new _exception2['default'](
+                'Template was precompiled with an older version of Handlebars than the current runtime. ' +
+                  'Please update your precompiler to a newer version (' +
+                  runtimeVersions +
+                  ') or downgrade your runtime to an older version (' +
+                  compilerVersions +
+                  ').'
+              )
+            } else {
+              // Use the embedded version info since the runtime doesn't know about this revision yet
+              throw new _exception2['default'](
+                'Template was precompiled with a newer version of Handlebars than the current runtime. ' +
+                  'Please update your runtime to a newer version (' +
+                  compilerInfo[1] +
+                  ').'
+              )
+            }
+          }
+        }
+
+        function template(templateSpec, env) {
+          /* istanbul ignore next */
+          if (!env) {
+            throw new _exception2['default']('No environment passed to template')
+          }
+          if (!templateSpec || !templateSpec.main) {
+            throw new _exception2['default']('Unknown template object: ' + typeof templateSpec)
+          }
+
+          templateSpec.main.decorator = templateSpec.main_d
+
+          // Note: Using env.VM references rather than local var references throughout this section to allow
+          // for external users to override these as psuedo-supported APIs.
+          env.VM.checkRevision(templateSpec.compiler)
+
+          function invokePartialWrapper(partial, context, options) {
+            if (options.hash) {
+              context = Utils.extend({}, context, options.hash)
+              if (options.ids) {
+                options.ids[0] = true
+              }
+            }
+
+            partial = env.VM.resolvePartial.call(this, partial, context, options)
+            var result = env.VM.invokePartial.call(this, partial, context, options)
+
+            if (result == null && env.compile) {
+              options.partials[options.name] = env.compile(partial, templateSpec.compilerOptions, env)
+              result = options.partials[options.name](context, options)
+            }
+            if (result != null) {
+              if (options.indent) {
+                var lines = result.split('\n')
+                for (var i = 0, l = lines.length; i < l; i++) {
+                  if (!lines[i] && i + 1 === l) {
+                    break
+                  }
+
+                  lines[i] = options.indent + lines[i]
+                }
+                result = lines.join('\n')
+              }
+              return result
+            } else {
+              throw new _exception2['default'](
+                'The partial ' + options.name + ' could not be compiled when running in runtime-only mode'
+              )
+            }
+          }
+
+          // Just add water
+          var container = {
+            strict: function strict(obj, name) {
+              if (!(name in obj)) {
+                throw new _exception2['default']('"' + name + '" not defined in ' + obj)
+              }
+              return obj[name]
+            },
+            lookup: function lookup(depths, name) {
+              var len = depths.length
+              for (var i = 0; i < len; i++) {
+                if (depths[i] && depths[i][name] != null) {
+                  return depths[i][name]
+                }
+              }
+            },
+            lambda: function lambda(current, context) {
+              return typeof current === 'function' ? current.call(context) : current
+            },
+
+            escapeExpression: Utils.escapeExpression,
+            invokePartial: invokePartialWrapper,
+
+            fn: function fn(i) {
+              var ret = templateSpec[i]
+              ret.decorator = templateSpec[i + '_d']
+              return ret
+            },
+
+            programs: [],
+            program: function program(i, data, declaredBlockParams, blockParams, depths) {
+              var programWrapper = this.programs[i],
+                fn = this.fn(i)
+              if (data || depths || blockParams || declaredBlockParams) {
+                programWrapper = wrapProgram(this, i, fn, data, declaredBlockParams, blockParams, depths)
+              } else if (!programWrapper) {
+                programWrapper = this.programs[i] = wrapProgram(this, i, fn)
+              }
+              return programWrapper
+            },
+
+            data: function data(value, depth) {
+              while (value && depth--) {
+                value = value._parent
+              }
+              return value
+            },
+            merge: function merge(param, common) {
+              var obj = param || common
+
+              if (param && common && param !== common) {
+                obj = Utils.extend({}, common, param)
+              }
+
+              return obj
+            },
+            // An empty object to use as replacement for null-contexts
+            nullContext: _Object$seal({}),
+
+            noop: env.VM.noop,
+            compilerInfo: templateSpec.compiler
+          }
+
+          function ret(context) {
+            var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1]
+
+            var data = options.data
+
+            ret._setup(options)
+            if (!options.partial && templateSpec.useData) {
+              data = initData(context, data)
+            }
+            var depths = undefined,
+              blockParams = templateSpec.useBlockParams ? [] : undefined
+            if (templateSpec.useDepths) {
+              if (options.depths) {
+                depths = context != options.depths[0] ? [context].concat(options.depths) : options.depths
+              } else {
+                depths = [context]
+              }
+            }
+
+            function main(context /*, options*/) {
+              return (
+                '' +
+                templateSpec.main(container, context, container.helpers, container.partials, data, blockParams, depths)
+              )
+            }
+            main = executeDecorators(templateSpec.main, main, container, options.depths || [], data, blockParams)
+            return main(context, options)
+          }
+          ret.isTop = true
+
+          ret._setup = function(options) {
+            if (!options.partial) {
+              container.helpers = container.merge(options.helpers, env.helpers)
+
+              if (templateSpec.usePartial) {
+                container.partials = container.merge(options.partials, env.partials)
+              }
+              if (templateSpec.usePartial || templateSpec.useDecorators) {
+                container.decorators = container.merge(options.decorators, env.decorators)
+              }
+            } else {
+              container.helpers = options.helpers
+              container.partials = options.partials
+              container.decorators = options.decorators
+            }
+          }
+
+          ret._child = function(i, data, blockParams, depths) {
+            if (templateSpec.useBlockParams && !blockParams) {
+              throw new _exception2['default']('must pass block params')
+            }
+            if (templateSpec.useDepths && !depths) {
+              throw new _exception2['default']('must pass parent depths')
+            }
+
+            return wrapProgram(container, i, templateSpec[i], data, 0, blockParams, depths)
+          }
+          return ret
+        }
+
+        function wrapProgram(container, i, fn, data, declaredBlockParams, blockParams, depths) {
+          function prog(context) {
+            var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1]
+
+            var currentDepths = depths
+            if (depths && context != depths[0] && !(context === container.nullContext && depths[0] === null)) {
+              currentDepths = [context].concat(depths)
+            }
+
+            return fn(
+              container,
+              context,
+              container.helpers,
+              container.partials,
+              options.data || data,
+              blockParams && [options.blockParams].concat(blockParams),
+              currentDepths
+            )
+          }
+
+          prog = executeDecorators(fn, prog, container, depths, data, blockParams)
+
+          prog.program = i
+          prog.depth = depths ? depths.length : 0
+          prog.blockParams = declaredBlockParams || 0
+          return prog
+        }
+
+        function resolvePartial(partial, context, options) {
+          if (!partial) {
+            if (options.name === '@partial-block') {
+              partial = options.data['partial-block']
+            } else {
+              partial = options.partials[options.name]
+            }
+          } else if (!partial.call && !options.name) {
+            // This is a dynamic partial that returned a string
+            options.name = partial
+            partial = options.partials[partial]
+          }
+          return partial
+        }
+
+        function invokePartial(partial, context, options) {
+          // Use the current closure context to save the partial-block if this partial
+          var currentPartialBlock = options.data && options.data['partial-block']
+          options.partial = true
+          if (options.ids) {
+            options.data.contextPath = options.ids[0] || options.data.contextPath
+          }
+
+          var partialBlock = undefined
+          if (options.fn && options.fn !== noop) {
+            ;(function() {
+              options.data = _base.createFrame(options.data)
+              // Wrapper function to get access to currentPartialBlock from the closure
+              var fn = options.fn
+              partialBlock = options.data['partial-block'] = function partialBlockWrapper(context) {
+                var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1]
+
+                // Restore the partial-block from the closure for the execution of the block
+                // i.e. the part inside the block of the partial call.
+                options.data = _base.createFrame(options.data)
+                options.data['partial-block'] = currentPartialBlock
+                return fn(context, options)
+              }
+              if (fn.partials) {
+                options.partials = Utils.extend({}, options.partials, fn.partials)
+              }
+            })()
+          }
+
+          if (partial === undefined && partialBlock) {
+            partial = partialBlock
+          }
+
+          if (partial === undefined) {
+            throw new _exception2['default']('The partial ' + options.name + ' could not be found')
+          } else if (partial instanceof Function) {
+            return partial(context, options)
+          }
+        }
+
+        function noop() {
+          return ''
+        }
+
+        function initData(context, data) {
+          if (!data || !('root' in data)) {
+            data = data ? _base.createFrame(data) : {}
+            data.root = context
+          }
+          return data
+        }
+
+        function executeDecorators(fn, prog, container, depths, data, blockParams) {
+          if (fn.decorator) {
+            var props = {}
+            prog = fn.decorator(prog, props, container, depths && depths[0], data, blockParams, depths)
+            Utils.extend(prog, props)
+          }
+          return prog
+        }
+
+        /***/
+      },
+      /* 22 */
+      /***/ function(module, exports, __webpack_require__) {
+        module.exports = { default: __webpack_require__(23), __esModule: true }
+
+        /***/
+      },
+      /* 23 */
+      /***/ function(module, exports, __webpack_require__) {
+        __webpack_require__(24)
+        module.exports = __webpack_require__(29).Object.seal
+
+        /***/
+      },
+      /* 24 */
+      /***/ function(module, exports, __webpack_require__) {
+        // 19.1.2.17 Object.seal(O)
+        var isObject = __webpack_require__(25)
+
+        __webpack_require__(26)('seal', function($seal) {
+          return function seal(it) {
+            return $seal && isObject(it) ? $seal(it) : it
+          }
+        })
+
+        /***/
+      },
+      /* 25 */
+      /***/ function(module, exports) {
+        module.exports = function(it) {
+          return typeof it === 'object' ? it !== null : typeof it === 'function'
+        }
+
+        /***/
+      },
+      /* 26 */
+      /***/ function(module, exports, __webpack_require__) {
+        // most Object methods by ES6 should accept primitives
+        var $export = __webpack_require__(27),
+          core = __webpack_require__(29),
+          fails = __webpack_require__(32)
+        module.exports = function(KEY, exec) {
+          var fn = (core.Object || {})[KEY] || Object[KEY],
+            exp = {}
+          exp[KEY] = exec(fn)
+          $export(
+            $export.S +
+              $export.F *
+                fails(function() {
+                  fn(1)
+                }),
+            'Object',
+            exp
+          )
+        }
+
+        /***/
+      },
+      /* 27 */
+      /***/ function(module, exports, __webpack_require__) {
+        var global = __webpack_require__(28),
+          core = __webpack_require__(29),
+          ctx = __webpack_require__(30),
+          PROTOTYPE = 'prototype'
+
+        var $export = function(type, name, source) {
+          var IS_FORCED = type & $export.F,
+            IS_GLOBAL = type & $export.G,
+            IS_STATIC = type & $export.S,
+            IS_PROTO = type & $export.P,
+            IS_BIND = type & $export.B,
+            IS_WRAP = type & $export.W,
+            exports = IS_GLOBAL ? core : core[name] || (core[name] = {}),
+            target = IS_GLOBAL ? global : IS_STATIC ? global[name] : (global[name] || {})[PROTOTYPE],
+            key,
+            own,
+            out
+          if (IS_GLOBAL) source = name
+          for (key in source) {
+            // contains in native
+            own = !IS_FORCED && target && key in target
+            if (own && key in exports) continue
+            // export native or passed
+            out = own ? target[key] : source[key]
+            // prevent global pollution for namespaces
+            exports[key] =
+              IS_GLOBAL && typeof target[key] != 'function'
+                ? source[key]
+                : // bind timers to global for call from export context
+                  IS_BIND && own
+                  ? ctx(out, global)
+                  : // wrap global constructors for prevent change them in library
+                    IS_WRAP && target[key] == out
+                    ? (function(C) {
+                        var F = function(param) {
+                          return this instanceof C ? new C(param) : C(param)
+                        }
+                        F[PROTOTYPE] = C[PROTOTYPE]
+                        return F
+                        // make static versions for prototype methods
+                      })(out)
+                    : IS_PROTO && typeof out == 'function'
+                      ? ctx(Function.call, out)
+                      : out
+            if (IS_PROTO) (exports[PROTOTYPE] || (exports[PROTOTYPE] = {}))[key] = out
+          }
+        }
+        // type bitmap
+        $export.F = 1 // forced
+        $export.G = 2 // global
+        $export.S = 4 // static
+        $export.P = 8 // proto
+        $export.B = 16 // bind
+        $export.W = 32 // wrap
+        module.exports = $export
+
+        /***/
+      },
+      /* 28 */
+      /***/ function(module, exports) {
+        // https://github.com/zloirock/core-js/issues/86#issuecomment-115759028
+        var global = (module.exports =
+          typeof window != 'undefined' && window.Math == Math
+            ? window
+            : typeof self != 'undefined' && self.Math == Math
+              ? self
+              : Function('return this')())
+        if (typeof __g == 'number') __g = global // eslint-disable-line no-undef
+
+        /***/
+      },
+      /* 29 */
+      /***/ function(module, exports) {
+        var core = (module.exports = { version: '1.2.6' })
+        if (typeof __e == 'number') __e = core // eslint-disable-line no-undef
+
+        /***/
+      },
+      /* 30 */
+      /***/ function(module, exports, __webpack_require__) {
+        // optional / simple context binding
+        var aFunction = __webpack_require__(31)
+        module.exports = function(fn, that, length) {
+          aFunction(fn)
+          if (that === undefined) return fn
+          switch (length) {
+            case 1:
+              return function(a) {
+                return fn.call(that, a)
+              }
+            case 2:
+              return function(a, b) {
+                return fn.call(that, a, b)
+              }
+            case 3:
+              return function(a, b, c) {
+                return fn.call(that, a, b, c)
+              }
+          }
+          return function(/* ...args */) {
+            return fn.apply(that, arguments)
+          }
+        }
+
+        /***/
+      },
+      /* 31 */
+      /***/ function(module, exports) {
+        module.exports = function(it) {
+          if (typeof it != 'function') throw TypeError(it + ' is not a function!')
+          return it
+        }
+
+        /***/
+      },
+      /* 32 */
+      /***/ function(module, exports) {
+        module.exports = function(exec) {
+          try {
+            return !!exec()
+          } catch (e) {
+            return true
+          }
+        }
+
+        /***/
+      },
+      /* 33 */
+      /***/ function(module, exports) {
+        /* WEBPACK VAR INJECTION */ ;(function(global) {
+          /* global window */
+          'use strict'
+
+          exports.__esModule = true
+
+          exports['default'] = function(Handlebars) {
+            /* istanbul ignore next */
+            var root = typeof global !== 'undefined' ? global : window,
+              $Handlebars = root.Handlebars
+            /* istanbul ignore next */
+            Handlebars.noConflict = function() {
+              if (root.Handlebars === Handlebars) {
+                root.Handlebars = $Handlebars
+              }
+              return Handlebars
+            }
+          }
+
+          module.exports = exports['default']
+          /* WEBPACK VAR INJECTION */
+        }.call(
+          exports,
+          (function() {
+            return this
+          })()
+        ))
+
+        /***/
+      }
+      /******/
+    ]
+  )
+})

--- a/manifest.json
+++ b/manifest.json
@@ -1,51 +1,36 @@
 {
-    "author": "John Murphy - Gateway Apps, LLC",
-    "content_scripts": [
-        {
-            "matches": [
-                "*://github.com/*/*/issues/*"
-            ],
-            "js": [
-                "jquery/jquery-3.2.0.min.js",
-                "handlebars.runtime-v4.0.10.js",
-                "app.js",
-                "template.js"
-            ],
-            "css": [
-                "css/style.css"
-            ],
-            "run_at": "document_end"
-        }
-    ],
-    "background": {
-        "scripts":["background.js"]
-    },
-    "description": "This extension shows a button on Github issue pages that can be used to clone github issues across repositories",
-    "icons": {
-        "128": "icons/storm-trooper-128.png"
-    },
-    "content_security_policy": "script-src 'self' https://code.jquery.com/jquery-3.2.1.min.js https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js 'unsafe-eval'; object-src 'self'; style-src 'self' https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css 'unsafe-inline';",
-    "manifest_version": 2,
-    "name": "Kamino",
-    "options_page": "options.html",
-    "permissions": [
-        "tabs",
-        "background",
-        "storage",
-        "webNavigation",
-        "*://github.com/*"
-    ],
-    "version": "2.9.2",
-    "web_accessible_resources":[
-        "icons/*.png",
-        "bootstrap/js/bootstrap.min.js",
-        "css/*.css",
-        "jquery/jquery-3.2.0.min.js",
-        "handlebars.runtime-v4.0.10.js",
-        "template.js",
-        "app.js",
-        "options.html",
-        "options.js",
-        "background.js"
-    ]
+  "author": "John Murphy - Gateway Apps, LLC",
+  "content_scripts": [
+    {
+      "matches": ["*://github.com/*/*/issues/*"],
+      "js": ["jquery/jquery-3.2.0.min.js", "handlebars.runtime-v4.0.10.js", "app.js", "template.js"],
+      "css": ["css/style.css"],
+      "run_at": "document_end"
+    }
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "description": "This extension shows a button on Github issue pages that can be used to clone github issues across repositories",
+  "icons": {
+    "128": "icons/storm-trooper-128.png"
+  },
+  "content_security_policy": "script-src 'self' https://code.jquery.com/jquery-3.2.1.min.js https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js 'unsafe-eval'; object-src 'self'; style-src 'self' https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css 'unsafe-inline';",
+  "manifest_version": 2,
+  "name": "Kamino",
+  "options_page": "options.html",
+  "permissions": ["tabs", "background", "storage", "webNavigation", "*://github.com/*"],
+  "version": "2.9.2",
+  "web_accessible_resources": [
+    "icons/*.png",
+    "bootstrap/js/bootstrap.min.js",
+    "css/*.css",
+    "jquery/jquery-3.2.0.min.js",
+    "handlebars.runtime-v4.0.10.js",
+    "template.js",
+    "app.js",
+    "options.html",
+    "options.js",
+    "background.js"
+  ]
 }

--- a/options.js
+++ b/options.js
@@ -1,42 +1,46 @@
 // Saves options to chrome.storage
 function save_options() {
-  var token = document.getElementById('github-pat').value;
-  var goToList = document.getElementById('go-to-issue-list').checked;
-  var createTab = document.getElementById('create-tab').checked;
+  var token = document.getElementById('github-pat').value
+  var goToList = document.getElementById('go-to-issue-list').checked
+  var createTab = document.getElementById('create-tab').checked
 
-  chrome.storage.sync.set({
-    githubToken: token,
-    goToList: goToList,
-    createTab: createTab
-  }, function() {
-    // Update status to let user know options were saved.
-    var status = document.getElementById('status');
-    status.textContent = 'Settings saved.';
-    setTimeout(function() {
-      status.textContent = '';
-    }, 750);
-  });
+  chrome.storage.sync.set(
+    {
+      githubToken: token,
+      goToList: goToList,
+      createTab: createTab
+    },
+    function() {
+      // Update status to let user know options were saved.
+      var status = document.getElementById('status')
+      status.textContent = 'Settings saved.'
+      setTimeout(function() {
+        status.textContent = ''
+      }, 750)
+    }
+  )
 }
 
 function paypal_donate() {
-  window.open('https://www.paypal.me/johnmurphy01', '_blank');
+  window.open('https://www.paypal.me/johnmurphy01', '_blank')
 }
 
 // Restores options
 function restore_options() {
-  chrome.storage.sync.get({
-    githubToken: '',
-    goToList: false,
-    createTab: true
-  }, function(items) {
-    document.getElementById('github-pat').value = items.githubToken;
-    document.getElementById('go-to-issue-list').checked = items.goToList;
-    document.getElementById('create-tab').checked = items.createTab;
-  });
+  chrome.storage.sync.get(
+    {
+      githubToken: '',
+      goToList: false,
+      createTab: true
+    },
+    function(items) {
+      document.getElementById('github-pat').value = items.githubToken
+      document.getElementById('go-to-issue-list').checked = items.goToList
+      document.getElementById('create-tab').checked = items.createTab
+    }
+  )
 }
 
-document.addEventListener('DOMContentLoaded', restore_options);
-document.getElementById('saveButton').addEventListener('click',
-    save_options);
-document.getElementById('paypal-button').addEventListener('click',
-    paypal_donate);
+document.addEventListener('DOMContentLoaded', restore_options)
+document.getElementById('saveButton').addEventListener('click', save_options)
+document.getElementById('paypal-button').addEventListener('click', paypal_donate)

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  semi: false,
+  singleQuote: true,
+  arrowParens: 'always',
+  printWidth: 120,
+  useTabs: false,
+  tabWidth: 2
+}

--- a/template.js
+++ b/template.js
@@ -1,13 +1,36 @@
-(function() {
-  var template = Handlebars.template, templates = Handlebars.templates = Handlebars.templates || {};
-templates['button'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"discussion-sidebar-item sidebar-kamino\">\r\n    <button class=\"discussion-sidebar-heading kamino-heading discussion-sidebar-toggle js-menu-target\">\r\n    <svg class=\"octicon octicon-gear\" viewBox=\"0 0 14 16\" version=\"1.1\" width=\"14\" height=\"16\" aria-hidden=\"true\">\r\n        <path fill-rule=\"evenodd\" d=\"M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z\"></path>\r\n    </svg>\r\n    Kamino\r\n    </button>\r\n    \r\n    <div class=\"btn-group\" role=\"group\">\r\n        <button type=\"button\" class=\"btn btn-sm btn-primary quickClone\">Clone to</button>\r\n        <button type=\"button\" class=\"btn btn-sm btn-primary dropdown-toggle kaminoButton\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\">\r\n            <span class=\"caret\"></span>\r\n            <span class=\"sr-only\">Toggle Dropdown</span>\r\n        </button>\r\n\r\n        <div class=\"dropdown-menu repoDropdownContainer\">\r\n            <input class=\"repoSearch\" type=\"text\" placeholder=\"Search for a repo...\" />\r\n            <hr/>\r\n            <ul class=\"repoDropdown\"></ul>\r\n        </div>\r\n    </div>\r\n</div>";
-},"useData":true});
-templates['modal'] = template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    var helper;
+;(function() {
+  var template = Handlebars.template,
+    templates = (Handlebars.templates = Handlebars.templates || {})
+  templates['button'] = template({
+    compiler: [7, '>= 4.0.0'],
+    main: function(container, depth0, helpers, partials, data) {
+      return '<div class="discussion-sidebar-item sidebar-kamino">\r\n    <button class="discussion-sidebar-heading kamino-heading discussion-sidebar-toggle js-menu-target">\r\n    <svg class="octicon octicon-gear" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true">\r\n        <path fill-rule="evenodd" d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"></path>\r\n    </svg>\r\n    Kamino\r\n    </button>\r\n    \r\n    <div class="btn-group" role="group">\r\n        <button type="button" class="btn btn-sm btn-primary quickClone">Clone to</button>\r\n        <button type="button" class="btn btn-sm btn-primary dropdown-toggle kaminoButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">\r\n            <span class="caret"></span>\r\n            <span class="sr-only">Toggle Dropdown</span>\r\n        </button>\r\n\r\n        <div class="dropdown-menu repoDropdownContainer">\r\n            <input class="repoSearch" type="text" placeholder="Search for a repo..." />\r\n            <hr/>\r\n            <ul class="repoDropdown"></ul>\r\n        </div>\r\n    </div>\r\n</div>'
+    },
+    useData: true
+  })
+  templates['modal'] = template({
+    compiler: [7, '>= 4.0.0'],
+    main: function(container, depth0, helpers, partials, data) {
+      var helper
 
-  return "<div id=\"kaminoModal\" class=\"modal fade\" role=\"dialog\">\r\n    <div class=\"modal-dialog\">\r\n        <div class=\"modal-content\">\r\n            <div class=\"modal-header\">\r\n                <button type=\"button\" class=\"close\" data-dismiss=\"modal\">&times;</button>\r\n                <h4 class=\"modal-title\">Kamino - Confirm Clone</h4>\r\n            </div>\r\n            <div class=\"modal-body\">\r\n                <p class=\"confirmText\">"
-    + container.escapeExpression(((helper = (helper = helpers.confirmText || (depth0 != null ? depth0.confirmText : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"confirmText","hash":{},"data":data}) : helper)))
-    + "</p>\r\n            </div>\r\n            <div class=\"modal-footer\">\r\n                <button type=\"button\" class=\"btn btn-primary cloneAndClose\" style=\"margin-right:20px;\" data-dismiss=\"modal\" data-repo=\"\">Clone and Close</button>\r\n                <button type=\"button\" class=\"btn btn-primary cloneAndKeepOpen\" style=\"margin-right:20px;\" data-dismiss=\"modal\" data-repo=\"\">Just Clone</button>\r\n                <button type=\"button\" class=\"btn btn-info noClone\" data-dismiss=\"modal\">Nevermind</button>\r\n            </div>\r\n        </div>\r\n    </div>\r\n</div>";
-},"useData":true});
-})();
+      return (
+        '<div id="kaminoModal" class="modal fade" role="dialog">\r\n    <div class="modal-dialog">\r\n        <div class="modal-content">\r\n            <div class="modal-header">\r\n                <button type="button" class="close" data-dismiss="modal">&times;</button>\r\n                <h4 class="modal-title">Kamino - Confirm Clone</h4>\r\n            </div>\r\n            <div class="modal-body">\r\n                <p class="confirmText">' +
+        container.escapeExpression(
+          ((helper =
+            (helper = helpers.confirmText || (depth0 != null ? depth0.confirmText : depth0)) != null
+              ? helper
+              : helpers.helperMissing),
+          typeof helper === 'function'
+            ? helper.call(depth0 != null ? depth0 : container.nullContext || {}, {
+                name: 'confirmText',
+                hash: {},
+                data: data
+              })
+            : helper)
+        ) +
+        '</p>\r\n            </div>\r\n            <div class="modal-footer">\r\n                <button type="button" class="btn btn-primary cloneAndClose" style="margin-right:20px;" data-dismiss="modal" data-repo="">Clone and Close</button>\r\n                <button type="button" class="btn btn-primary cloneAndKeepOpen" style="margin-right:20px;" data-dismiss="modal" data-repo="">Just Clone</button>\r\n                <button type="button" class="btn btn-info noClone" data-dismiss="modal">Nevermind</button>\r\n            </div>\r\n        </div>\r\n    </div>\r\n</div>'
+      )
+    },
+    useData: true
+  })
+})()


### PR DESCRIPTION
- Setup prettier config in `prettier.config.js`
- Ran command `prettier --write "./*.{js,json}"` on the codebase

References #118 
Options implemented

- [x] no semi-colons at the end of lines
- [x] single quote for strings unless using template literals
- [] arrow functions
- [x] arrow function params should have parenthesis around it:
```
((param1, param2) => {
})
```
- [] space between if and conditional:
```
if (stuff) { }
```
- [] { not on own line

Note: Unmarked features have no corresponding options in `prettier`, `eslint` might be a better option if the unmarked options have a high priority
