### PR TITLE
use an existing css variable for modal background

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -189,15 +189,15 @@ a {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background-color: var(--color-bg-canvas);
+  background-color: var(--color-workflow-card-bg);
   -webkit-background-clip: padding-box;
   background-clip: padding-box;
-  border: 1px solid var(--color-text-primary);
+  border: 1px solid var(--color-accent-fg);
   border-radius: 6px;
   outline: 0;
-  -webkit-box-shadow: 0 3px 9px var(--color-text-primary);
-  box-shadow: 0 3px 9px var(--color-text-primary);
-  color: var(--color-text-primary);
+  -webkit-box-shadow: 0 3px 9px var(--color-accent-fg);
+  box-shadow: 0 3px 9px var(--color-accent-fg);
+  color: var(--color-accent-fg);
 }
 
 .modal-header {


### PR DESCRIPTION
Fixes #184 

Github changed their available CSS variables which broke some of the Kamino styling. I am now using a new set for the modal contents which should solve the problem(until they change their variables again). 