### PR TITLE
Prevent mentions/notifications by replacing @username with links

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,7 @@
         "Repos",
         "kamino",
         "linkstring"
-    ]
+    ],
+    "html.format.indentInnerHtml": true,
+    "html.format.wrapAttributes": "preserve"
 }

--- a/options.html
+++ b/options.html
@@ -58,6 +58,13 @@
             <label><input class="me-2" type="checkbox" id="disable-comment-on-original" />Disable Kamino automatic
               comments on original issue</label>
           </div>
+
+          <div class="checkbox">
+            <label><input class="me-2" type="checkbox" id="prevent-references" />Prevent references to cloned issue on
+              original issue
+              (using <a href="https://github.com/orgs/community/discussions/23123#discussioncomment-3239240">this hacky
+                method</a>)</label>
+          </div>
         </div>
 
         <p class="mt-2">

--- a/options.html
+++ b/options.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
   <head>
     <title>Kamino Settings</title>
     <link rel="stylesheet" href="css/options.css" />
@@ -7,8 +8,7 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6"
-      crossorigin="anonymous"
-    />
+      crossorigin="anonymous" />
   </head>
 
   <body>
@@ -42,7 +42,8 @@
           </div>
 
           <div class="checkbox">
-            <label><input class="me-2" type="checkbox" id="go-to-issue-list" />Go to original repo's issue list after cloning</label>
+            <label><input class="me-2" type="checkbox" id="go-to-issue-list" />Go to original repo's issue list after
+              cloning</label>
           </div>
 
           <div class="checkbox">
@@ -54,10 +55,8 @@
           </div>
 
           <div class="checkbox">
-            <label
-              ><input class="me-2" type="checkbox" id="disable-comment-on-original" />Disable Kamino automatic comments on original
-              issue</label
-            >
+            <label><input class="me-2" type="checkbox" id="disable-comment-on-original" />Disable Kamino automatic
+              comments on original issue</label>
           </div>
         </div>
 
@@ -77,8 +76,8 @@
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf"
-      crossorigin="anonymous"
-    ></script>
+      crossorigin="anonymous"></script>
     <script src="options.js"></script>
   </body>
+
 </html>

--- a/options.html
+++ b/options.html
@@ -65,6 +65,12 @@
               (using <a href="https://github.com/orgs/community/discussions/23123#discussioncomment-3239240">this hacky
                 method</a>)</label>
           </div>
+
+          <div class="checkbox">
+            <label><input class="me-2" type="checkbox" id="prevent-mentions" />Prevent notifications to users mentioned
+              in the cloned issues/comments (by replacing all occurences of @username with a link; <strong>be
+                warned</strong> this will do the replacement even inside of code blocks)</label>
+          </div>
         </div>
 
         <p class="mt-2">

--- a/options.js
+++ b/options.js
@@ -5,6 +5,7 @@ function save_options() {
   const createTab = document.getElementById('create-tab').checked
   const cloneComments = document.getElementById('clone-comments').checked
   const disableCommentsOnOriginal = document.getElementById('disable-comment-on-original')
+  const preventReferences = document.getElementById('prevent-references')
 
   chrome.storage.sync.set(
     {
@@ -13,6 +14,7 @@ function save_options() {
       createTab,
       cloneComments,
       disableCommentsOnOriginal,
+      preventReferences
     },
     function () {
       // Update status to let user know options were saved.
@@ -38,6 +40,7 @@ function restore_options() {
       createTab: true,
       cloneComments: false,
       disableCommentsOnOriginal: false,
+      preventReferences: false,
     },
     function (items) {
       document.getElementById('github-pat').value = items.githubToken
@@ -45,6 +48,7 @@ function restore_options() {
       document.getElementById('create-tab').checked = items.createTab
       document.getElementById('clone-comments').checked = items.cloneComments
       document.getElementById('disable-comment-on-original').checked = items.disableCommentsOnOriginal
+      document.getElementById('prevent-references').checked = items.preventReferences
     }
   )
 }

--- a/options.js
+++ b/options.js
@@ -6,6 +6,7 @@ function save_options() {
   const cloneComments = document.getElementById('clone-comments').checked
   const disableCommentsOnOriginal = document.getElementById('disable-comment-on-original')
   const preventReferences = document.getElementById('prevent-references')
+  const preventMentions = document.getElementById('prevent-mentions')
 
   chrome.storage.sync.set(
     {
@@ -14,7 +15,8 @@ function save_options() {
       createTab,
       cloneComments,
       disableCommentsOnOriginal,
-      preventReferences
+      preventReferences,
+      preventMentions,
     },
     function () {
       // Update status to let user know options were saved.
@@ -41,6 +43,7 @@ function restore_options() {
       cloneComments: false,
       disableCommentsOnOriginal: false,
       preventReferences: false,
+      preventMentions: false,
     },
     function (items) {
       document.getElementById('github-pat').value = items.githubToken
@@ -49,6 +52,7 @@ function restore_options() {
       document.getElementById('clone-comments').checked = items.cloneComments
       document.getElementById('disable-comment-on-original').checked = items.disableCommentsOnOriginal
       document.getElementById('prevent-references').checked = items.preventReferences
+      document.getElementById('prevent-mentions').checked = items.preventMentions
     }
   )
 }

--- a/templates/button.handlebars
+++ b/templates/button.handlebars
@@ -1,21 +1,24 @@
 <div class="discussion-sidebar-item sidebar-kamino">
     <button class="discussion-sidebar-heading kamino-heading discussion-sidebar-toggle js-menu-target">
-    <svg class="octicon octicon-gear" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true">
-        <path fill-rule="evenodd" d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z"></path>
-    </svg>
-    Kamino
+        <svg class="octicon octicon-gear" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true">
+            <path fill-rule="evenodd"
+                d="M14 8.77v-1.6l-1.94-.64-.45-1.09.88-1.84-1.13-1.13-1.81.91-1.09-.45-.69-1.92h-1.6l-.63 1.94-1.11.45-1.84-.88-1.13 1.13.91 1.81-.45 1.09L0 7.23v1.59l1.94.64.45 1.09-.88 1.84 1.13 1.13 1.81-.91 1.09.45.69 1.92h1.59l.63-1.94 1.11-.45 1.84.88 1.13-1.13-.92-1.81.47-1.09L14 8.75v.02zM7 11c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3z">
+            </path>
+        </svg>
+        Kamino
     </button>
-    
+
     <div class="btn-group" role="group">
         <button type="button" class="btn btn-sm btn-primary quickClone">Clone to</button>
-        <button type="button" class="btn btn-sm btn-primary dropdown-toggle kaminoButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button type="button" class="btn btn-sm btn-primary dropdown-toggle kaminoButton" data-toggle="dropdown"
+            aria-haspopup="true" aria-expanded="false">
             <span class="caret"></span>
             <span class="sr-only">Toggle Dropdown</span>
         </button>
 
         <div class="dropdown-menu repoDropdownContainer">
             <input class="repoSearch" type="text" placeholder="Search for a repo..." />
-            <hr/>
+            <hr />
             <ul class="repoDropdown"></ul>
         </div>
     </div>

--- a/templates/modal.handlebars
+++ b/templates/modal.handlebars
@@ -9,8 +9,10 @@
                 <p class="confirmText">{{confirmText}}</p>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-primary cloneAndClose" style="margin-right:20px;" data-dismiss="modal" data-repo="">Clone and Close</button>
-                <button type="button" class="btn btn-primary cloneAndKeepOpen" style="margin-right:20px;" data-dismiss="modal" data-repo="">Just Clone</button>
+                <button type="button" class="btn btn-primary cloneAndClose" style="margin-right:20px;"
+                    data-dismiss="modal" data-repo="">Clone and Close</button>
+                <button type="button" class="btn btn-primary cloneAndKeepOpen" style="margin-right:20px;"
+                    data-dismiss="modal" data-repo="">Just Clone</button>
                 <button type="button" class="btn btn-info noClone" data-dismiss="modal">Nevermind</button>
             </div>
         </div>


### PR DESCRIPTION
(Stacked PR on top of #188 #189 #190)

When cloning many issues+comments, there's a high chance that you may end up notifying dozens or hundreds of users due to the @username mentions.

This PR adds a configurable option to use a regex to replace all mentions with links to the user profile.