### PR TITLE
support github enterprise urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ If you don't know how to create a PAT or need help, check out Creating a token s
 
 Once you have your PAT, enter it on the Options screen for Kamino and click `Save`. After that is done, go to any GitHub issue page in which you are a member and you should see a button labeled `Clone to`.
 
+Kamino also supports GitHub Enterprise Server hosts such as `https://github.mycompany.com`. For Enterprise use, create the PAT on that Enterprise host; Kamino will use that host's `/api/v3` API instead of `api.github.com`.
+
 # Features
 
 ## Settings

--- a/app.js
+++ b/app.js
@@ -18,11 +18,21 @@ if (token === '') {
 }
 
 function initializeExtension() {
-  const { currentRepo, error, issueNumber, organization, url } = populateUrlMetadata(document.location.href)
+  const {
+    currentRepo,
+    error,
+    githubApiUrl: currentGithubApiUrl,
+    githubOrigin,
+    issueNumber,
+    organization,
+    url,
+  } = populateUrlMetadata(document.location.href)
 
   if (error) {
     return
   }
+
+  githubApiUrl = currentGithubApiUrl
 
   if (!isIssueDetailUrl({ currentRepo, issueNumber, organization, url })) {
     return
@@ -43,7 +53,7 @@ function initializeExtension() {
   }
 
   intervalIds.forEach(clearInterval)
-  saveAppliedFilters({ currentRepo, issueNumber, organization, url })
+  saveAppliedFilters({ currentRepo, githubOrigin, issueNumber, organization, url })
 
   const kaminoButton = $(Handlebars.templates.button().replace(/(\r\n|\n|\r)/gm, ''))
   const modalContext = {
@@ -126,7 +136,7 @@ function isIssueDetailUrl(urlMetadata) {
 }
 
 function saveAppliedFilters(urlMetadata) {
-  const { currentRepo, issueNumber, organization, url } = urlMetadata
+  const { currentRepo, githubOrigin, issueNumber, organization, url } = urlMetadata
 
   // url should have /issues and should not track any url that has an issue number at the end
   if (url.indexOf('/issues') > 0 && isNaN(issueNumber)) {
@@ -139,6 +149,7 @@ function saveAppliedFilters(urlMetadata) {
 
     var newFilter = {
       filter: querystring,
+      githubOrigin,
       organization,
       currentRepo,
     }
@@ -283,11 +294,15 @@ function searchRepositories(searchTerm) {
 }
 
 async function getGithubIssue(repo, closeOriginal) {
-  const { currentRepo, error, issueNumber, organization } = populateUrlMetadata(document.location.href)
+  const { currentRepo, error, githubApiUrl: currentGithubApiUrl, issueNumber, organization } = populateUrlMetadata(
+    document.location.href
+  )
 
   if (error) {
     return
   }
+
+  githubApiUrl = currentGithubApiUrl
 
   const repoName = repo.split('/')[1]
 
@@ -365,11 +380,15 @@ function createClonedCommentBody(comment, options) {
 }
 
 async function createGithubIssue(repo, oldIssue, closeOriginal) {
-  const { currentRepo, error, issueNumber, organization } = populateUrlMetadata(document.location.href)
+  const { currentRepo, error, githubApiUrl: currentGithubApiUrl, issueNumber, organization } = populateUrlMetadata(
+    document.location.href
+  )
 
   if (error) {
     return
   }
+
+  githubApiUrl = currentGithubApiUrl
 
   const options = await getSyncStorage({
     addBlockquote: true,
@@ -428,21 +447,33 @@ async function closeGithubIssue() {
     state: 'closed',
   }
 
-  const { currentRepo, error, issueNumber, organization } = populateUrlMetadata(document.location.href)
+  const { currentRepo, error, githubApiUrl: currentGithubApiUrl, issueNumber, organization } = populateUrlMetadata(
+    document.location.href
+  )
 
   if (error) {
     return
   }
+
+  githubApiUrl = currentGithubApiUrl
 
   await ajaxRequest('PATCH', issueToClose, `${githubApiUrl}repos/${organization}/${currentRepo}/issues/${issueNumber}`)
 }
 
 async function commentOnIssue(repo, newIssue, closeOriginal) {
-  const { currentRepo, error, issueNumber, organization } = populateUrlMetadata(document.location.href)
+  const {
+    currentRepo,
+    error,
+    githubApiUrl: currentGithubApiUrl,
+    issueNumber,
+    organization,
+  } = populateUrlMetadata(document.location.href)
 
   if (error) {
     return
   }
+
+  githubApiUrl = currentGithubApiUrl
 
   const newIssueLink = `[${repo}](${newIssue.html_url})`
   const comment = {
@@ -467,7 +498,11 @@ async function commentOnIssue(repo, newIssue, closeOriginal) {
 }
 
 function goToIssueList(repo, issueNumber, org, oldRepo) {
-  chrome.runtime.sendMessage({ repo: repo, issueNumber: issueNumber, organization: org, oldRepo: oldRepo }, () => {})
+  const { githubOrigin } = populateUrlMetadata(document.location.href)
+  chrome.runtime.sendMessage(
+    { repo: repo, issueNumber: issueNumber, organization: org, oldRepo: oldRepo, githubOrigin },
+    () => {}
+  )
 }
 
 function delay(milliseconds) {

--- a/background.js
+++ b/background.js
@@ -1,3 +1,7 @@
+if (typeof importScripts === 'function') {
+  importScripts('lib/populateUrlMetadata.js')
+}
+
 async function getCurrentTab() {
   let queryOptions = { active: true, lastFocusedWindow: true }
   // `tab` will either be a `tabs.Tab` instance or `undefined`.
@@ -5,9 +9,21 @@ async function getCurrentTab() {
   return tab
 }
 
+function canRunKaminoOnUrl(url) {
+  if (!url) {
+    return false
+  }
+
+  return !populateUrlMetadata(url).error
+}
+
+function getGithubOrigin(request) {
+  return request.githubOrigin || 'https://github.com'
+}
+
 // used when Github uses push state.
 chrome.webNavigation.onHistoryStateUpdated.addListener(async (details) => {
-  if (details.frameId !== 0 || !details.url || !details.url.startsWith('https://github.com/')) {
+  if (details.frameId !== 0 || !canRunKaminoOnUrl(details.url)) {
     return
   }
 
@@ -45,6 +61,8 @@ chrome.runtime.onMessage.addListener((request) => {
   if (request.action && request.action === 'goToOptions') {
     chrome.tabs.create({ url: `chrome-extension://${chrome.runtime.id}/options.html`, selected: true })
   } else {
+    const githubOrigin = getGithubOrigin(request)
+
     chrome.storage.sync.get(
       {
         goToList: false,
@@ -58,7 +76,11 @@ chrome.runtime.onMessage.addListener((request) => {
           const filterList = typeof item.filters === 'string' ? [] : item.filters
 
           var f = filterList.filter((i) => {
-            return i.organization === request.organization && i.currentRepo === request.oldRepo
+            return (
+              (i.githubOrigin || 'https://github.com') === githubOrigin &&
+              i.organization === request.organization &&
+              i.currentRepo === request.oldRepo
+            )
           })
 
           var filter = {
@@ -71,12 +93,12 @@ chrome.runtime.onMessage.addListener((request) => {
           setTimeout(async () => {
             if (item.createTab) {
               await chrome.tabs.create({
-                url: `https://github.com/${request.repo}/issues/${request.issueNumber}`,
+                url: `${githubOrigin}/${request.repo}/issues/${request.issueNumber}`,
                 selected: false,
               })
             }
             await chrome.tabs.update(tabs[0].id, {
-              url: `https://github.com/${request.organization}/${request.oldRepo}${filter.filter}`,
+              url: `${githubOrigin}/${request.organization}/${request.oldRepo}${filter.filter}`,
               selected: true,
             })
           }, 1000)
@@ -84,7 +106,7 @@ chrome.runtime.onMessage.addListener((request) => {
           if (item.createTab) {
             setTimeout(async () => {
               await chrome.tabs.create({
-                url: `https://github.com/${request.repo}/issues/${request.issueNumber}`,
+                url: `${githubOrigin}/${request.repo}/issues/${request.issueNumber}`,
                 selected: true,
               })
             }, 1000)

--- a/batch.js
+++ b/batch.js
@@ -31,6 +31,8 @@ function initializeBatchExtension() {
     return
   }
 
+  batchGithubApiUrl = urlObj.githubApiUrl
+
   const mountTarget = getBatchMountTarget()
 
   if (mountTarget.length === 0) {
@@ -282,11 +284,15 @@ function searchRepositories(searchTerm) {
 }
 
 async function getGithubIssue(destinationRepo, sourceIssueNumber, closeOriginal) {
-  const { currentRepo, error, organization } = populateUrlMetadata(document.location.href)
+  const { currentRepo, error, githubApiUrl: currentGithubApiUrl, organization } = populateUrlMetadata(
+    document.location.href
+  )
 
   if (error) {
     return
   }
+
+  batchGithubApiUrl = currentGithubApiUrl
 
   const repoName = destinationRepo.split('/')[1]
 
@@ -367,11 +373,15 @@ function createClonedCommentBody(comment, options) {
 
 // create the cloned GitHub issue
 async function createGithubIssue(repo, oldIssue, closeOriginal) {
-  const { currentRepo, error, organization } = populateUrlMetadata(document.location.href)
+  const { currentRepo, error, githubApiUrl: currentGithubApiUrl, organization } = populateUrlMetadata(
+    document.location.href
+  )
 
   if (error) {
     return
   }
+
+  batchGithubApiUrl = currentGithubApiUrl
 
   const options = await getBatchSyncStorage({
     addBlockquote: true,
@@ -433,6 +443,12 @@ async function closeGithubIssue(oldIssue) {
 
   const urlObj = populateUrlMetadata(document.location.href)
 
+  if (urlObj.error) {
+    return
+  }
+
+  batchGithubApiUrl = urlObj.githubApiUrl
+
   updateMessageText(`Closing issue #${oldIssue.number}`)
   await ajaxRequest(
     'PATCH',
@@ -444,6 +460,13 @@ async function closeGithubIssue(oldIssue) {
 
 async function commentOnIssue(repo, oldIssue, newIssue, closeOriginal) {
   const urlObj = populateUrlMetadata(document.location.href)
+
+  if (urlObj.error) {
+    return
+  }
+
+  batchGithubApiUrl = urlObj.githubApiUrl
+
   const newIssueLink = `[${repo}](${newIssue.html_url})`
   const comment = {
     body: closeOriginal

--- a/e2e/kamino-extension.playwright.js
+++ b/e2e/kamino-extension.playwright.js
@@ -19,6 +19,11 @@ const contentScriptFiles = [
 ]
 
 const appContentScriptFiles = contentScriptFiles.filter((file) => file !== 'batch.js')
+const githubOrigin = 'https://github.com'
+const githubApiOrigin = 'https://api.github.com'
+const enterpriseOrigin = 'https://github.mycompany.com'
+const enterpriseApiOrigin = `${enterpriseOrigin}/api/v3`
+const nonGithubOrigin = 'https://example.com'
 
 const repos = [
   { full_name: 'gatewayapps/kamino' },
@@ -31,13 +36,13 @@ const issues = [
   {
     body: sourceIssueBody,
     created_at: '2026-01-01T00:00:00Z',
-    html_url: 'https://github.com/gatewayapps/kamino/issues/123',
+    html_url: `${githubOrigin}/gatewayapps/kamino/issues/123`,
     labels: [],
     number: 123,
     pull_request: undefined,
     title: 'Issue 123',
     user: {
-      html_url: 'https://github.com/octocat',
+      html_url: `${githubOrigin}/octocat`,
       id: 583231,
       login: 'octocat',
     },
@@ -67,17 +72,24 @@ async function jsonResponse(route, body) {
   })
 }
 
-async function installMocks(context) {
-  await context.route('https://api.github.com/repos/**', (route) => jsonResponse(route, {}))
-  await context.route('https://api.github.com/user/repos?**', (route) => jsonResponse(route, repos))
-  await context.route(/https:\/\/api\.github\.com\/repos\/gatewayapps\/kamino\/issues\?.*/, (route) =>
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+async function installApiMocks(context, apiOrigin) {
+  await context.route(`${apiOrigin}/repos/**`, (route) => jsonResponse(route, {}))
+  await context.route(`${apiOrigin}/user/repos?**`, (route) => jsonResponse(route, repos))
+  await context.route(new RegExp(`${escapeRegex(apiOrigin)}/repos/gatewayapps/kamino/issues\\?.*`), (route) =>
     jsonResponse(route, issues)
   )
-  await context.route(/https:\/\/api\.github\.com\/repos\/gatewayapps\/kamino\/issues\/123(?:\?.*)?$/, (route) =>
-    jsonResponse(route, issues[0])
+  await context.route(
+    new RegExp(`${escapeRegex(apiOrigin)}/repos/gatewayapps/kamino/issues/123(?:\\?.*)?$`),
+    (route) => jsonResponse(route, issues[0])
   )
+}
 
-  await context.route('https://github.com/**', (route) => {
+async function installGithubPageMocks(context, githubOrigin) {
+  await context.route(`${githubOrigin}/**`, (route) => {
     const url = new URL(route.request().url())
     const isIssueDetail = url.pathname === '/gatewayapps/kamino/issues/123'
 
@@ -89,6 +101,14 @@ async function installMocks(context) {
       }),
     })
   })
+}
+
+async function installMocks(context) {
+  await installGithubPageMocks(context, githubOrigin)
+  await installGithubPageMocks(context, enterpriseOrigin)
+  await installGithubPageMocks(context, nonGithubOrigin)
+  await installApiMocks(context, githubApiOrigin)
+  await installApiMocks(context, enterpriseApiOrigin)
 }
 
 async function launchExtension(testInfo) {
@@ -116,8 +136,8 @@ async function launchExtension(testInfo) {
   return context
 }
 
-async function openMockRepoPage(page) {
-  await page.goto('https://github.com/gatewayapps/kamino')
+async function openMockRepoPage(page, origin = githubOrigin) {
+  await page.goto(`${origin}/gatewayapps/kamino`)
 }
 
 async function softNavigate(page, path, bodyHtml) {
@@ -189,12 +209,23 @@ test.describe('Kamino extension smoke tests', () => {
     context = await launchExtension(testInfo)
     page = await context.newPage()
 
-    await page.goto('https://github.com/gatewayapps/kamino/issues/123')
+    await page.goto(`${githubOrigin}/gatewayapps/kamino/issues/123`)
     await page.bringToFront()
     await injectKaminoContentScripts(context, page.url(), appContentScriptFiles)
 
     await expect(page.locator('.sidebar-kamino')).toBeVisible()
     await expect(page.locator('.batchButton')).toHaveCount(0)
+  })
+
+  test('does not render on non-github hosts with github-like issue paths', async ({}, testInfo) => {
+    context = await launchExtension(testInfo)
+    page = await context.newPage()
+
+    await page.goto(`${nonGithubOrigin}/gatewayapps/kamino/issues/123`)
+    await page.bringToFront()
+    await injectKaminoContentScripts(context, page.url(), appContentScriptFiles)
+
+    await expect(page.locator('.sidebar-kamino')).toHaveCount(0)
   })
 
   test('recovers batch cloning after GitHub redraws the issue toolbar', async ({}, testInfo) => {
@@ -214,6 +245,17 @@ test.describe('Kamino extension smoke tests', () => {
     await expect(page.locator('.batchButton')).toBeVisible()
   })
 
+  test('shows batch cloning on github enterprise issue lists', async ({}, testInfo) => {
+    context = await launchExtension(testInfo)
+    page = await context.newPage()
+
+    await openMockRepoPage(page, enterpriseOrigin)
+    await softNavigate(page, '/gatewayapps/kamino/issues?q=is%3Aclosed+is%3Aissue')
+
+    await expect(page.locator('.batchButton')).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Batch Clone' })).toBeEnabled()
+  })
+
   test('preserves source markdown when source attribution and blockquotes are disabled', async ({}, testInfo) => {
     context = await launchExtension(testInfo)
 
@@ -230,13 +272,13 @@ test.describe('Kamino extension smoke tests', () => {
     const createIssueRequest = new Promise((resolve) => {
       resolveCreateIssueRequest = resolve
     })
-    await context.route('https://api.github.com/repos/gatewayapps/target-repo/issues', async (route) => {
+    await context.route(`${githubApiOrigin}/repos/gatewayapps/target-repo/issues`, async (route) => {
       if (route.request().method() === 'POST') {
         const createIssuePayload = route.request().postDataJSON()
         resolveCreateIssueRequest(createIssuePayload)
 
         await jsonResponse(route, {
-          html_url: 'https://github.com/gatewayapps/target-repo/issues/456',
+          html_url: `${githubOrigin}/gatewayapps/target-repo/issues/456`,
           number: 456,
         })
         return
@@ -246,7 +288,7 @@ test.describe('Kamino extension smoke tests', () => {
     })
 
     page = await context.newPage()
-    await page.goto('https://github.com/gatewayapps/kamino/issues/123')
+    await page.goto(`${githubOrigin}/gatewayapps/kamino/issues/123`)
     await page.bringToFront()
     await injectKaminoContentScripts(context, page.url(), appContentScriptFiles)
 
@@ -257,5 +299,51 @@ test.describe('Kamino extension smoke tests', () => {
     const createIssuePayload = await createIssueRequest
 
     expect(createIssuePayload.body).toBe(sourceIssueBody)
+  })
+
+  test('uses the enterprise api when cloning enterprise issues', async ({}, testInfo) => {
+    context = await launchExtension(testInfo)
+
+    await setExtensionStorage(context, {
+      addBlockquote: false,
+      cloneComments: false,
+      createTab: false,
+      disableCommentsOnOriginal: true,
+      githubToken: 'token',
+      mostUsed: ['gatewayapps/target-repo'],
+    })
+
+    let resolveCreateIssueRequest
+    const createIssueRequest = new Promise((resolve) => {
+      resolveCreateIssueRequest = resolve
+    })
+    await context.route(`${enterpriseApiOrigin}/repos/gatewayapps/target-repo/issues`, async (route) => {
+      if (route.request().method() === 'POST') {
+        const createIssuePayload = route.request().postDataJSON()
+        resolveCreateIssueRequest({ payload: createIssuePayload, url: route.request().url() })
+
+        await jsonResponse(route, {
+          html_url: `${enterpriseOrigin}/gatewayapps/target-repo/issues/456`,
+          number: 456,
+        })
+        return
+      }
+
+      await jsonResponse(route, {})
+    })
+
+    page = await context.newPage()
+    await page.goto(`${enterpriseOrigin}/gatewayapps/kamino/issues/123`)
+    await page.bringToFront()
+    await injectKaminoContentScripts(context, page.url(), appContentScriptFiles)
+
+    await expect(page.locator('.quickClone[data-repo="gatewayapps/target-repo"]')).toBeVisible()
+    await page.locator('.quickClone').click()
+    await page.locator('.cloneAndKeepOpen').click()
+
+    const createIssuePayload = await createIssueRequest
+
+    expect(createIssuePayload.url).toBe(`${enterpriseApiOrigin}/repos/gatewayapps/target-repo/issues`)
+    expect(createIssuePayload.payload.body).toBe(sourceIssueBody)
   })
 })

--- a/lib/createFilters.js
+++ b/lib/createFilters.js
@@ -8,7 +8,18 @@ function createFilters(newFilter, item) {
   }
 
   item.filters.forEach((filter) => {
-    exists = filter.organization === newFilter.organization && filter.currentRepo === newFilter.currentRepo
+    const filterOrigin = filter.githubOrigin || 'https://github.com'
+    const newFilterOrigin = newFilter.githubOrigin || 'https://github.com'
+    const isMatchingFilter =
+      filterOrigin === newFilterOrigin &&
+      filter.organization === newFilter.organization &&
+      filter.currentRepo === newFilter.currentRepo
+
+    if (!isMatchingFilter) {
+      return
+    }
+
+    exists = true
 
     if (filter.filter !== newFilter.filter) {
       changed = true

--- a/lib/populateUrlMetadata.js
+++ b/lib/populateUrlMetadata.js
@@ -1,26 +1,52 @@
+function getGithubApiUrl(origin) {
+  const githubUrl = new URL(origin)
+
+  if (githubUrl.hostname === 'github.com') {
+    return 'https://api.github.com/'
+  }
+
+  return `${githubUrl.origin}/api/v3/`
+}
+
+function isSupportedGithubHost(hostname) {
+  const normalizedHostname = hostname.toLowerCase()
+  return normalizedHostname === 'github.com' || normalizedHostname.startsWith('github.')
+}
+
 function populateUrlMetadata(href) {
+  let parsedUrl
+
+  try {
+    parsedUrl = new URL(href)
+  } catch {
+    return { error: 'Cannot parse this url' }
+  }
+
+  if (!isSupportedGithubHost(parsedUrl.hostname)) {
+    return { error: 'Unsupported GitHub host' }
+  }
+
   const url = href
-  const urlArray = url.split('/')
+  const pathParts = parsedUrl.pathname.split('/').filter(Boolean)
 
-  if (urlArray.length >= 7) {
-    const currentRepo = urlArray[4]
-    const organization = urlArray[3]
-    const issueNumber = urlArray[urlArray.length - 1].replace('#', '')
-
+  if (pathParts.length >= 4 && pathParts[2] === 'issues') {
     return {
       url,
-      currentRepo,
-      organization,
-      issueNumber,
+      currentRepo: pathParts[1],
+      githubApiUrl: getGithubApiUrl(parsedUrl.origin),
+      githubOrigin: parsedUrl.origin,
+      githubHost: parsedUrl.hostname,
+      organization: pathParts[0],
+      issueNumber: pathParts[3],
     }
-  } else if (urlArray.length >= 6) {
-    const currentRepo = urlArray[4]
-    const organization = urlArray[3]
-
+  } else if (pathParts.length === 3 && pathParts[2] === 'issues') {
     return {
       url,
-      currentRepo,
-      organization,
+      currentRepo: pathParts[1],
+      githubApiUrl: getGithubApiUrl(parsedUrl.origin),
+      githubOrigin: parsedUrl.origin,
+      githubHost: parsedUrl.hostname,
+      organization: pathParts[0],
       issueNumber: undefined,
     }
   }
@@ -30,4 +56,6 @@ function populateUrlMetadata(href) {
 
 if (typeof module !== 'undefined') {
   module.exports = populateUrlMetadata
+  module.exports.getGithubApiUrl = getGithubApiUrl
+  module.exports.isSupportedGithubHost = isSupportedGithubHost
 }

--- a/lib/preventReferences.js
+++ b/lib/preventReferences.js
@@ -1,6 +1,16 @@
-function preventReferences(text) {
-  // replace "github.com" links with "www.github.com" links, which do not cause references on the original issue due to the "www" (see https://github.com/orgs/community/discussions/23123#discussioncomment-3239240)
-  return text.replace(/https:\/\/github.com\//gi, 'https://www.github.com/')
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+function preventReferences(text, githubHost) {
+  const host =
+    githubHost ||
+    (typeof window !== 'undefined' && window.location && window.location.hostname) ||
+    'github.com'
+  const referenceLink = new RegExp(`https://${escapeRegex(host)}/`, 'gi')
+
+  // Add "www." to same-host GitHub links so cloned content does not notify the original issue.
+  return text.replace(referenceLink, `https://www.${host}/`)
 }
 
 if (typeof module !== 'undefined') {

--- a/manifest.json
+++ b/manifest.json
@@ -2,8 +2,8 @@
   "author": "John Murphy - Gateway Apps, LLC",
   "content_scripts": [
     {
-      "matches": ["*://github.com/*/*/issues"],
-      "exclude_matches": ["*://github.com/*/*/issues/*"],
+      "matches": ["*://*/*/*/issues"],
+      "exclude_matches": ["*://*/*/*/issues/*"],
       "js": [
         "./jquery/jquery-3.6.0.min.js",
         "./handlebars.runtime.min-v4.7.7.js",
@@ -19,8 +19,8 @@
       "run_at": "document_end"
     },
     {
-      "matches": ["*://github.com/*/*/issues/*"],
-      "exclude_matches": ["*://github.com/*/*/issues"],
+      "matches": ["*://*/*/*/issues/*"],
+      "exclude_matches": ["*://*/*/*/issues"],
       "js": [
         "./jquery/jquery-3.6.0.min.js",
         "./handlebars.runtime.min-v4.7.7.js",
@@ -47,8 +47,8 @@
   "name": "Kamino",
   "options_page": "options.html",
   "permissions": ["background", "scripting", "storage", "webNavigation"],
-  "host_permissions": ["*://github.com/*"],
-  "version": "4.2.1",
+  "host_permissions": ["*://*/*", "*://api.github.com/*"],
+  "version": "4.3.0",
   "web_accessible_resources": [
     {
       "resources": [
@@ -69,7 +69,7 @@
         "options.js",
         "background.js"
       ],
-      "matches": ["*://github.com/*"]
+      "matches": ["*://*/*"]
     }
   ]
 }

--- a/tests/createFilters.spec.js
+++ b/tests/createFilters.spec.js
@@ -21,6 +21,7 @@ describe('createFilter', () => {
     const { changed, filters } = createFilters(newFilter, existingFilters)
     expect(filters).toHaveLength(2)
     expect(changed).toBeTruthy()
+    expect(filters[0].filter).toEqual('another-filter')
     expect(filters[1].filter).toEqual('test-filter')
   })
 
@@ -68,5 +69,31 @@ describe('createFilter', () => {
     expect(filters).toHaveLength(1)
     expect(changed).toEqual(false)
     expect(filters[0].filter).toEqual('test-filter')
+  })
+
+  it('keeps filters separate for github enterprise hosts', () => {
+    const newFilter = {
+      filter: 'enterprise-filter',
+      githubOrigin: 'https://github.mycompany.com',
+      organization: 'gatewayapps',
+      currentRepo: 'kamino',
+    }
+
+    const existingFilters = {
+      filters: [
+        {
+          filter: 'github-filter',
+          githubOrigin: 'https://github.com',
+          organization: 'gatewayapps',
+          currentRepo: 'kamino',
+        },
+      ],
+    }
+
+    const { changed, filters } = createFilters(newFilter, existingFilters)
+    expect(filters).toHaveLength(2)
+    expect(changed).toBeTruthy()
+    expect(filters[0].filter).toEqual('github-filter')
+    expect(filters[1].filter).toEqual('enterprise-filter')
   })
 })

--- a/tests/populateUrlMetadata.spec.js
+++ b/tests/populateUrlMetadata.spec.js
@@ -4,6 +4,8 @@ describe('populateUrlMetadata', () => {
   it('takes a url and returns an object populated with all of the metadata necessary for the url', () => {
     const urlMetadata = populateUrlMetadata('https://github.com/gatewayapps/kamino/issues/5')
     expect(urlMetadata.currentRepo).toEqual('kamino')
+    expect(urlMetadata.githubApiUrl).toEqual('https://api.github.com/')
+    expect(urlMetadata.githubOrigin).toEqual('https://github.com')
     expect(urlMetadata.issueNumber).toEqual('5')
     expect(urlMetadata.organization).toEqual('gatewayapps')
     expect(urlMetadata.url).toEqual('https://github.com/gatewayapps/kamino/issues/5')
@@ -20,5 +22,19 @@ describe('populateUrlMetadata', () => {
     expect(urlMetadata.issueNumber).toEqual(undefined)
     expect(urlMetadata.organization).toEqual('gatewayapps')
     expect(urlMetadata.url).toEqual('https://github.com/gatewayapps/kamino/issues?q=is%3Aopen+is%3Aissue')
+  })
+
+  it('supports github enterprise issue urls', () => {
+    const urlMetadata = populateUrlMetadata('https://github.mycompany.com/gatewayapps/kamino/issues/5')
+    expect(urlMetadata.currentRepo).toEqual('kamino')
+    expect(urlMetadata.githubApiUrl).toEqual('https://github.mycompany.com/api/v3/')
+    expect(urlMetadata.githubOrigin).toEqual('https://github.mycompany.com')
+    expect(urlMetadata.issueNumber).toEqual('5')
+    expect(urlMetadata.organization).toEqual('gatewayapps')
+  })
+
+  it('does not support non-github hosts with github-like paths', () => {
+    const urlMetadata = populateUrlMetadata('https://example.com/gatewayapps/kamino/issues/5')
+    expect(urlMetadata.error).toEqual('Unsupported GitHub host')
   })
 })

--- a/tests/preventReferences.spec.js
+++ b/tests/preventReferences.spec.js
@@ -7,4 +7,13 @@ describe('preventReferences', () => {
     const alteredText = preventReferences(originalText)
     expect(alteredText).toEqual(`This is text with a url: https://www.github.com/`)
   })
+
+  it('updates urls for github enterprise hosts', () => {
+    const originalText = 'This is text with a url: https://github.mycompany.com/gatewayapps/kamino/issues/1'
+
+    const alteredText = preventReferences(originalText, 'github.mycompany.com')
+    expect(alteredText).toEqual(
+      'This is text with a url: https://www.github.mycompany.com/gatewayapps/kamino/issues/1'
+    )
+  })
 })


### PR DESCRIPTION
Fixes #199

Add support for github enterprise urls. Do not support any urls that do not have `github` as part of the base url.